### PR TITLE
feat: 支持 web-widget > script[type=data] 存放数据

### DIFF
--- a/docs/docs/container/tag.md
+++ b/docs/docs/container/tag.md
@@ -66,9 +66,28 @@
 
 ## 数据
 
-通过 `data` 或 `data-*` 属性可以为 Web Widget 应用传递静态的数据：
+有 3 种方式为应用传递数据：
+
+1. `data` 属性：支持 JSON 数据结构
+2. `web-widget > script[type=data]` 元素：支持 JSON 数据结构，它适合存放较大的数据内容
+3. `data-*` 属性：只支持 `string` 类型
 
 ```html
+<web-widget
+  src="app.widget.js"
+  data="{&quot;id&quot;:&quot;#345&quot;,&quot;username&quot;:&quot;widget&quot;}"
+>
+</web-widget>
+
+<web-widget src="app.widget.js">
+  <script type="data">
+    {
+      "username": "hello",
+      "uid": "xxxx-xxxx-xxxx-xxxx"
+    }
+  </script>
+</web-widget>
+
 <web-widget
   src="app.widget.js"
   data-username="web-widget"
@@ -87,8 +106,6 @@ export default () => ({
   }
 });
 ```
-
-> 通过 `data-*` 只能传递 `string` 类型的值；使用 `data` 属性可以使用 JSON 字符串，它将自动解析成 `object`。
 
 ## 沙盒
 

--- a/packages/container/examples/data/index.html
+++ b/packages/container/examples/data/index.html
@@ -11,24 +11,44 @@
 <body>
 
   <web-widget
-    id="widget"
-    data="{&quot;id&quot;:&quot;#345&quot;,&quot;username&quot;:&quot;widget&quot;}"
-    data-id="@123"
+    name="demo-1"
+    data-username="@web-widget"
+    data-messges="hello wrold"
     src="./index.widget.js"
   >
   </web-widget>
-  <pre id="log"></pre>
+
+  <web-widget
+    name="demo-2"
+    data="{&quot;id&quot;:&quot;#345&quot;,&quot;username&quot;:&quot;widget&quot;}"
+    src="./index.widget.js"
+  >
+  </web-widget>
+
+  <web-widget
+    name="demo-3"
+    src="./index.widget.js"
+  >
+    <script type="data">
+      {
+        "username": "hello",
+        "uid": "xxxx-xxxx-xxxx-xxxx"
+      }
+    </script>
+  </web-widget>
 
   <script type="module">
     import '@web-widget/container';
 
     const { INITIAL, UPDATING, MOUNTED } = HTMLWebWidgetElement;
     let oldState = INITIAL;
-    document.getElementById('widget').addEventListener('statechange', function() {
-      if (oldState === UPDATING && this.state === MOUNTED) {
-        document.getElementById('log').innerText = JSON.stringify(this.data, null, 2)
-      }
-      oldState = this.state;
+    document.querySelectorAll('web-widget').forEach(widget => {
+      widget.addEventListener('statechange', function() {
+        if (oldState === UPDATING && this.state === MOUNTED) {
+          console.log(this.name, JSON.stringify(this.data, null, 2));
+        }
+        oldState = this.state;
+      });
     });
   </script>
 </body>

--- a/packages/container/examples/data/index.widget.js
+++ b/packages/container/examples/data/index.widget.js
@@ -15,7 +15,7 @@ export default () => {
       update.onclick = () => {
         context.update({
           data: {
-            id: data.id,
+            ...data,
             username: `@${Date.now()}`
           }
         });
@@ -23,8 +23,13 @@ export default () => {
       element.appendChild(update);
     },
 
-    async update() {
+    async update({ container, data }) {
       console.log('update');
+      container.querySelector('pre').textContent = JSON.stringify(
+        data,
+        null,
+        2
+      );
     },
 
     async unmount({ container }) {

--- a/packages/container/src/HTMLWebWidgetElement.js
+++ b/packages/container/src/HTMLWebWidgetElement.js
@@ -233,11 +233,21 @@ export class HTMLWebWidgetElement extends HTMLElement {
       return this[DATA];
     }
 
-    const dataAttr = this.getAttribute('data');
+    let rawJson = this.getAttribute('data');
 
-    if (dataAttr) {
+    if (!rawJson) {
+      for (const element of this.children) {
+        const localName = element.localName;
+        if (localName === 'script' && element.type === 'data') {
+          rawJson = element.text;
+          break;
+        }
+      }
+    }
+
+    if (rawJson) {
       try {
-        this[DATA] = JSON.parse(dataAttr);
+        this[DATA] = JSON.parse(rawJson);
         return this[DATA];
       } catch (error) {
         globalWebWidgetError.bind(this)(error);

--- a/packages/container/test/container.test.js
+++ b/packages/container/test/container.test.js
@@ -330,6 +330,40 @@ describe('Application property: data', () => {
       expect(getProperties().data).to.deep.equal(data);
     }));
 
+  it('Should support "web-widget > script[type=data]" to store JSON content', () =>
+    createWidget(async ({ widget, getProperties }) => {
+      const data = {
+        test: Date.now()
+      };
+      const script = document.createElement('script');
+      script.type = 'data';
+      script.text = JSON.stringify(data);
+      widget.appendChild(script);
+
+      await widget.mount();
+      expect(getProperties().data).to.deep.equal(data);
+      await widget.unload();
+      expect(getProperties().data).to.deep.equal(data);
+    }));
+
+  it('Should only support direct child element script [type=data] to store JSON data', () =>
+    createWidget(async ({ widget, getProperties }) => {
+      const data = {
+        test: Date.now()
+      };
+      const div = document.createElement('div');
+      const script = document.createElement('script');
+      script.type = 'data';
+      script.text = JSON.stringify(data);
+      div.appendChild(script);
+      widget.appendChild(div);
+
+      await widget.mount();
+      expect(getProperties().data).to.deep.equal({});
+      await widget.unload();
+      expect(getProperties().data).to.deep.equal({});
+    }));
+
   it('The priority of attributes and properties should be handled correctly', () =>
     createWidget(async ({ widget, getProperties }) => {
       const arrtData = {
@@ -363,6 +397,26 @@ describe('Application property: data', () => {
       await widget.unload();
       expect(getProperties().data).to.have.property('a', a);
       expect(getProperties().data).to.have.property('b', b);
+    }));
+
+  it('"data" should have a higher priority than "web-widget script[type=data]"', () =>
+    createWidget(async ({ widget, getProperties }) => {
+      const arrtData = {
+        test: Date.now()
+      };
+      const scriptData = {
+        test: 'priority'
+      };
+
+      widget.setAttribute('data', JSON.stringify(arrtData));
+
+      const script = document.createElement('script');
+      script.type = 'data';
+      script.text = JSON.stringify(scriptData);
+      widget.appendChild(script);
+
+      await widget.mount();
+      expect(getProperties().data).to.deep.equal(arrtData);
     }));
 });
 


### PR DESCRIPTION
此 PR 改进了数据存储方式的定义：支持 JSON 数据结构的同时减少体积。

这是目前的数据存储方式：

1. `data` 属性：支持 JSON 数据结构，但需要对双引号进行转义，数据量大的时候将对页面的体积有影响
2. `web-widget > script[type=data]` 元素：支持 JSON 数据结构，它适合存放较大的数据内容（当前 PR 增加的）
3. `data-*` 属性：属于 HTML5 标准，但只支持 `string` 类型

三者使用方式：

```html
<web-widget
  src="app.widget.js"
  data="{&quot;id&quot;:&quot;#345&quot;,&quot;username&quot;:&quot;widget&quot;}"
>
</web-widget>

<web-widget src="app.widget.js">
  <script type="data">
    {
      "username": "hello",
      "uid": "xxxx-xxxx-xxxx-xxxx"
    }
  </script>
</web-widget>

<web-widget
  src="app.widget.js"
  data-username="web-widget"
  data-email="web-widget@web-widget.js.org"
>
</web-widget>
```