### PR TITLE
fix: 保留部分构建注释

### DIFF
--- a/packages/container/src/loaders/module.js
+++ b/packages/container/src/loaders/module.js
@@ -14,7 +14,7 @@ function importModule(target) {
     // eslint-disable-next-line no-undef
     return importShim(target);
   }
-  return import(/* webpackIgnore: true */ target);
+  return import(/* @vite-ignore */ /* webpackIgnore: true */ target);
 }
 
 export async function moduleLoader(view) {

--- a/scripts/builder/src/rollup.config.js
+++ b/scripts/builder/src/rollup.config.js
@@ -29,7 +29,10 @@ export default () => {
   if (isProduction) {
     plugins.push(
       terser({
-        keep_classnames: true
+        keep_classnames: true,
+        format: {
+          comments: /(vite-ignore|webpackIgnore)/
+        }
       })
     );
   }


### PR DESCRIPTION
# 问题

- import(x) 完全动态的动态引入在 webpack 和 vite 会报警告

# 解决

增加构建工具专用注释，且在 rollup 配置内忽略专用注释剔除


