### PR TITLE
fix(dev): 海洋代码修改后没有引发界面更新

### DIFF
--- a/packages/builder/src/plugin/server/index.ts
+++ b/packages/builder/src/plugin/server/index.ts
@@ -12,7 +12,7 @@ export default function createVitePluginServer(): Plugin {
     async configureServer(viteServer) {
       const loader = createViteLoader(viteServer);
       let manifest: Manifest | void;
-      let pendingReload: DeferredPromise<Manifest> | void;
+      let pendingRebuild: DeferredPromise<Manifest> | void;
 
       /** rebuild the route cache + manifest, as needed. */
       async function rebuildManifest(
@@ -20,10 +20,10 @@ export default function createVitePluginServer(): Plugin {
         _file: string
       ) {
         if (needsManifestRebuild) {
-          pendingReload = new DeferredPromise<Manifest>()
+          pendingRebuild = new DeferredPromise<Manifest>()
           manifest = await getManifest(loader);
-          pendingReload.complete(manifest)
-          pendingReload = undefined;
+          pendingRebuild.complete(manifest)
+          pendingRebuild = undefined;
         }
       }
       // Rebuild route manifest on file change, if needed.
@@ -37,7 +37,7 @@ export default function createVitePluginServer(): Plugin {
           req,
           res
         ) {
-          if (pendingReload) await pendingReload.p;
+          if (pendingRebuild) await pendingRebuild.p;
           manifest = manifest || (await getManifest(loader));
           return handleRequest(manifest, viteServer, loader, req, res);
         });


### PR DESCRIPTION
1.修改海洋后，vite 发送给客户端的 full-reload 消息会比 manifest 重新加载要快.
为了保证正确的刷新，页面重新加载时需要等待 manifest 重新加载完.

2.海洋代码修改后，可能导致 export default 改变，应该重新加载 manifest.