### PR TITLE
refactor: 重新设计 context 的范式

### DIFF
--- a/examples/koa/routes/_middleware.ts
+++ b/examples/koa/routes/_middleware.ts
@@ -1,9 +1,11 @@
-export const handler = [
-  async function middleware1(req, ctx) {
+import type { MiddlewareHandler } from "@web-widget/web-server";
+
+export const handler: MiddlewareHandler[] = [
+  async function middleware1(ctx) {
     // do something
     return ctx.next();
   },
-  async function middleware2(req, ctx) {
+  async function middleware2(ctx) {
     // do something
     return ctx.next();
   },

--- a/examples/koa/routes/about.tsx
+++ b/examples/koa/routes/about.tsx
@@ -18,7 +18,7 @@ export const meta = defineMeta({
 });
 
 export const handler = defineRouteHandler<AboutPageData>({
-  async GET(req, ctx) {
+  async GET(ctx) {
     console.log(ctx.meta);
 
     const resp = await ctx.render({

--- a/examples/koa/routes/fallback.tsx
+++ b/examples/koa/routes/fallback.tsx
@@ -8,8 +8,8 @@ import {
 export { render };
 
 export const handler = defineRouteHandler({
-  async GET(req, ctx) {
-    const url = new URL(req.url);
+  async GET(ctx) {
+    const url = new URL(ctx.request.url);
 
     if (url.searchParams.has("404")) {
       return ctx.render({

--- a/examples/koa/routes/news.tsx
+++ b/examples/koa/routes/news.tsx
@@ -9,7 +9,7 @@ type NewsPageData = {
 };
 
 export const handler: Handlers<NewsPageData> = {
-  async GET(req, ctx) {
+  async GET(ctx) {
     const data = await fetch(new URL("../public/data.json", import.meta.url));
     return ctx.render({
       data: await data.json(),

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -203,7 +203,7 @@ export interface ServerRouteHandler<
   Data = unknown,
   State = Record<string, unknown>
 > {
-  (req: Request, ctx: ServerRouteHandlerContext<Data, State>):
+  (ctx: ServerRouteHandlerContext<Data, State>):
     | ServerRouteHandlerResult
     | Promise<ServerRouteHandlerResult>;
 }
@@ -212,7 +212,7 @@ export interface ClientRouteHandler<
   Data = unknown,
   State = Record<string, unknown>
 > {
-  (req: Request, ctx: ClientRouteHandlerContext<Data, State>):
+  (ctx: ClientRouteHandlerContext<Data, State>):
     | ClientRouteHandlerResult
     | Promise<ClientRouteHandlerResult>;
 }
@@ -240,6 +240,7 @@ export interface ServerRouteHandlerContext<
     },
     options?: ResponseInit
   ): ServerRouteHandlerResult | Promise<ServerRouteHandlerResult>;
+  request: Request;
   state: State;
 }
 
@@ -259,6 +260,7 @@ export interface ClientRouteHandlerContext<
     },
     options?: ResponseInit
   ): ClientRouteHandlerResult | Promise<ClientRouteHandlerResult>;
+  request: Request;
   state: State;
 }
 

--- a/packages/web-server/src/server/types.ts
+++ b/packages/web-server/src/server/types.ts
@@ -76,9 +76,10 @@ export interface PageLayoutData {
 
 export interface MiddlewareHandlerContext<State = Record<string, unknown>>
   extends ServerConnInfo {
-  next: () => Promise<Response>;
-  state: State;
   destination: router.DestinationKind;
+  next: () => Promise<Response>;
+  request: Request;
+  state: State;
 }
 
 export interface MiddlewareRoute extends Middleware {
@@ -93,7 +94,6 @@ export interface MiddlewareRoute extends Middleware {
 }
 
 export type MiddlewareHandler<State = Record<string, unknown>> = (
-  req: Request,
   ctx: MiddlewareHandlerContext<State>
 ) => Response | Promise<Response>;
 


### PR DESCRIPTION
新的范式示例：

```diff
export const handler: Handlers<NewsPageData> = {
-  async GET(req, ctx) {
+  async GET(ctx) {
+   const req = ctx.request;
    const data = await fetch(new URL("../public/data.json", import.meta.url));
    return ctx.render({
      data: await data.json(),
    });
  },
};
```

这样做的动机是为了后续能省略 handler，对于简单的 GET 请求直接在组件中处理，而 React 组件的风格是只有一个参数，我们在范式上保持和 React 社区一致。