### PR TITLE
feat: 增加 fallbacks 概念，增强渲染 HTTP 的灵活度

### DIFF
--- a/examples/koa/routemap.json
+++ b/examples/koa/routemap.json
@@ -1,34 +1,35 @@
 {
   "routes": [
     {
-      "name": "index",
       "pathname": "/",
       "module": "./routes/index.tsx"
     },
     {
-      "name": "about",
       "pathname": "/about",
       "module": "./routes/about.tsx"
     },
     {
-      "name": "news",
       "pathname": "/news",
       "module": "./routes/news.tsx"
     },
     {
-      "name": "fallback",
       "pathname": "/fallback",
       "module": "./routes/fallback.tsx"
     },
     {
-      "name": "experimental-async-component",
       "pathname": "/experimental-async-component",
       "module": "./routes/experimental-async-component.tsx"
     },
     {
-      "name": "style",
       "pathname": "/style",
       "module": "./routes/style.tsx"
+    }
+  ],
+  "fallbacks": [
+    {
+      "name": "NotFound",
+      "pathname": "/_404",
+      "module": "./routes/_404.tsx"
     }
   ],
   "middlewares": [
@@ -36,10 +37,5 @@
       "pathname": "{/*}?",
       "module": "./routes/_middleware.ts"
     }
-  ],
-  "notFound": {
-    "name": "_404",
-    "pathname": "/_404",
-    "module": "./routes/_404.tsx"
-  }
+  ]
 }

--- a/examples/koa/routes/_404.tsx
+++ b/examples/koa/routes/_404.tsx
@@ -1,9 +1,9 @@
-export { render } from '@web-widget/react';
+export { render } from "@web-widget/react";
 
 export default function Page404() {
   return (
     <main>
-      <h1>404</h1>
+      <h1>⚠️ 404 NotFound</h1>
     </main>
   );
 }

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -3,28 +3,6 @@ import type { z } from "zod";
 import type { OutgoingHttpHeaders } from "node:http";
 import { BuilderConfigSchema } from "./config/schema";
 
-export interface Input {
-  routes?: {
-    name: string;
-    pathname: string;
-    module: string;
-  }[];
-  middlewares?: {
-    pathname: string;
-    module: string;
-  }[];
-  notFound?: {
-    name: string;
-    pathname: string;
-    module: string;
-  };
-  error?: {
-    name: string;
-    pathname: string;
-    module: string;
-  };
-}
-
 export interface Output {
   dir?: string;
   client?: string;
@@ -48,7 +26,7 @@ export interface BuilderUserConfig {
   publicDir?: string;
   tempDir?: string;
   root?: string;
-  input?: Input;
+  input?: string;
   output?: Output;
   server?: Server | ((options: { command: "dev" | "preview" }) => Server);
   vite?: ViteConfig;

--- a/packages/web-server/src/server/index.ts
+++ b/packages/web-server/src/server/index.ts
@@ -1,10 +1,5 @@
 import { ServerContext } from "./context";
-import type {
-  StartOptions,
-  Manifest,
-  ServerHandler,
-  ServerConnInfo,
-} from "./types";
+import type { StartOptions, ServerHandler, ServerConnInfo } from "./types";
 export type * from "./types";
 
 export default class WebServer {

--- a/packages/web-server/src/server/render.ts
+++ b/packages/web-server/src/server/render.ts
@@ -1,12 +1,6 @@
 import * as layout from "./layout.default";
 import type { Page, PageLayoutData, RenderPage } from "./types";
-import type {
-  Meta,
-  RouteRenderResult,
-  RouteError,
-  RouteModule,
-  Module,
-} from "#schema";
+import type { Meta, RouteRenderResult, RouteError } from "#schema";
 import { nonce, NONE, UNSAFE_INLINE, ContentSecurityPolicy } from "./csp";
 
 export interface InnerRenderOptions<Data> {

--- a/packages/web-server/src/server/types.ts
+++ b/packages/web-server/src/server/types.ts
@@ -110,26 +110,22 @@ export interface Middleware<State = Record<string, unknown>> {
 // --- MANIFEST ---
 
 export interface Manifest {
-  routes: {
+  $schema?: string;
+  routes?: {
     name?: string;
     pathname: string;
     module: string;
   }[];
-  middlewares: {
+  middlewares?: {
     name?: string;
     pathname: string;
     module: string;
   }[];
-  notFound?: {
+  fallbacks?: {
     name?: string;
     pathname: string;
     module: string;
-  };
-  error?: {
-    name?: string;
-    pathname: string;
-    module: string;
-  };
+  }[];
 }
 
 // --- SERVERS ---


### PR DESCRIPTION
此 PR 提供了面向未来的设计，增强错误处理灵活性。

主要的变化是为 routemap.json 增加了 `fallbacks` 概念来自定义 HTTP 错误处理页面。它是一个数组，服务器通过 `name` 来匹配不同的 HTTP 错误页面渲染。

```diff
{
  "routes": [
     ...
  ],
-  "notFound": {
-    "name": "_404",
-    "pathname": "/_404",
-    "module": "./routes/_404.tsx"
-  }
+  "fallbacks": [
+    {
+      "name": "NotFound",
+      "pathname": "/_404",
+      "module": "./routes/_404.tsx"
+    },
+    {
+      "name": "InternalServerError",
+      "pathname": "/_500",
+      "module": "./routes/_500.tsx"
+    }
+  ],
  "middlewares": [
    ...
  ]
}
```

注意：当前 Web Server 只支持 404 和 500 错误渲染，尚未支持其它类型错误。