### PR TITLE
feat: Web Server 支持使用 URL 对象作为参数配置 manifestUrl

### DIFF
--- a/examples/web-server/server.js
+++ b/examples/web-server/server.js
@@ -20,7 +20,7 @@ app.use(async (ctx, next) => {
 });
 
 const webServer = new WebServer(
-  new URL("./dist/server/routemap.json", import.meta.url).href,
+  new URL("./dist/server/routemap.json", import.meta.url),
   {
     client: {
       base: "/",

--- a/packages/web-server/src/context.ts
+++ b/packages/web-server/src/context.ts
@@ -69,10 +69,14 @@ export class ServerContext {
    * Process the manifest into individual components and pages.
    */
   static async fromManifest(
-    manifestUrl: string,
+    manifestUrl: string | URL,
     opts: WebServerOptions,
     dev: boolean
   ): Promise<ServerContext> {
+    if (manifestUrl instanceof URL) {
+      manifestUrl = manifestUrl.href;
+    }
+
     if (typeof manifestUrl !== "string") {
       throw TypeError(`The manifestUrl parameter must be a string.`);
     }

--- a/packages/web-server/src/index.ts
+++ b/packages/web-server/src/index.ts
@@ -5,7 +5,7 @@ export type * from "./types";
 export default class WebServer {
   #handler: ServerHandler;
 
-  constructor(manifestUrl: string, opts: StartOptions = {}) {
+  constructor(manifestUrl: string | URL, opts: StartOptions = {}) {
     const promise = ServerContext.fromManifest(
       manifestUrl,
       opts,


### PR DESCRIPTION
类似 `fetch` API 一样，允许传入 `URL` 对象：

```diff
const webServer = new WebServer(
-  new URL("./dist/server/routemap.json", import.meta.url).href
+  new URL("./dist/server/routemap.json", import.meta.url)
);
```