### PR TITLE
fix: 修复构建后的模块可能存在无法找到的问题

### DIFF
--- a/packages/react/src/babel-plugin.ts
+++ b/packages/react/src/babel-plugin.ts
@@ -17,13 +17,14 @@
  * ...
  * <MyComponent title="My component" />
  */
-import { relative, dirname, join } from "node:path";
-import { declare } from "@babel/helper-plugin-utils";
-import { addNamed } from "@babel/helper-module-imports";
-import { types as t } from "@babel/core";
+import { dirname, join, relative } from "node:path";
+
+import type { DefineWebWidgetOptions } from "./web-widget";
 import type { PluginPass } from "@babel/core";
 import type { Visitor } from "@babel/traverse";
-import type { DefineWebWidgetOptions } from "./web-widget";
+import { addNamed } from "@babel/helper-module-imports";
+import { declare } from "@babel/helper-plugin-utils";
+import { types as t } from "@babel/core";
 
 function createWebWidgetVariableDeclaration(
   definer: string,
@@ -159,9 +160,10 @@ export default declare((api) => {
           "defineWebWidget",
           "@web-widget/react"
         );
-        const base =
-          config.base +
-          join(relative(config.root, dirname(state.filename)), "/");
+        // const base =
+        //   config.base +
+        //   join(relative(config.root, dirname(state.filename)), "/");
+        const base = config.base;
 
         binding.path.parentPath?.replaceWith(
           createWebWidgetVariableDeclaration(

--- a/packages/react/src/vite-plugin.ts
+++ b/packages/react/src/vite-plugin.ts
@@ -1,6 +1,7 @@
 import type { Plugin, PluginOption, ResolvedConfig } from "vite";
-import react from "@vitejs/plugin-react";
+
 import type { Options } from "@vitejs/plugin-react";
+import react from "@vitejs/plugin-react";
 
 export default function ReactWebWidgetVitePlugin(
   options: Options = {}
@@ -42,7 +43,10 @@ export default function ReactWebWidgetVitePlugin(
             "@web-widget/react/babel-plugin",
             {
               get base() {
-                return config.base;
+                const isServer = !!config.build.ssr;
+                return isServer
+                  ? config.base + config.build.assetsDir + "/"
+                  : config.base;
               },
               get root() {
                 return config.root;


### PR DESCRIPTION
为了让服务端和客户端资产路径保持一致，之前使用正则表达式来替换服务端中的模块地址，当不同层级的模块相对位置出现变化的时候，这就会导致无法找到模块。此问题的修复关键：通过 es-module-lexer 分析模块进行替换。