### PR TITLE
fix: 构建时应排除 node 原生模块

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@web-widget/express": "workspace:*",
+    "builtin-modules": "^3.3.0",
     "es-module-lexer": "^1.3.0 ",
     "import-meta-resolve": "^3.0.0",
     "mico-spinner": "^1.4.0",

--- a/packages/builder/src/build/index.ts
+++ b/packages/builder/src/build/index.ts
@@ -22,6 +22,7 @@ import mime from "mime-types";
 import { openConfig } from "../config";
 import { resolve } from "import-meta-resolve";
 import { withSpinner } from "./utils";
+import builtins from "builtin-modules";
 
 const VITE_MANIFEST_NAME = "manifest.json";
 const CLIENT_MODUL_NAME = "@web-widget/web-widget";
@@ -145,6 +146,7 @@ async function bundleWithVite(
           assetFileNames: `${config.output.asset}/[name]-[hash][extname]`,
           chunkFileNames: `${config.output.asset}/[name]-[hash].js`,
         },
+        external: builtins as string[],
       },
       server: {
         host: config.server.host,
@@ -255,13 +257,10 @@ function chunkFileNamesPlugin(chunkMap: Map<string, string>): VitePlugin[] {
           chunk.dynamicImports = chunk.dynamicImports.map(getNewFileName);
           chunk.importedBindings = Object.entries(
             chunk.importedBindings
-          ).reduce(
-            (map, [key, value]) => {
-              map[key] = value;
-              return map;
-            },
-            {} as { [imported: string]: string[] }
-          );
+          ).reduce((map, [key, value]) => {
+            map[key] = value;
+            return map;
+          }, {} as { [imported: string]: string[] });
           chunk.implicitlyLoadedBefore =
             chunk.implicitlyLoadedBefore.map(getNewFileName);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ importers:
       '@web-widget/web-widget':
         specifier: workspace:*
         version: link:../web-widget
+      builtin-modules:
+        specifier: ^3.3.0
+        version: 3.3.0
       es-module-lexer:
         specifier: '^1.3.0 '
         version: 1.3.0
@@ -4833,7 +4836,6 @@ packages:
   /builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
-    dev: true
 
   /builtins@4.1.0:
     resolution: {integrity: sha512-1bPRZQtmKaO6h7qV1YHXNtr6nCK28k0Zo95KM4dXfILcZZwoHJBN1m3lfLv9LPkcOZlrSr+J1bzMaZFO98Yq0w==}


### PR DESCRIPTION
当使用vue2构建时，会发出错误：
![image](https://github.com/web-widget/web-widget/assets/28132598/a6e9b2a9-7a58-4eb3-930e-4eb392f888b9)
提示不能构建 node 原生模块，所以在构建时需要排除所有的 node 原生模块