### PR TITLE
fix: 修复可能出现的循环依赖导致无法正确构建的问题

### DIFF
--- a/packages/builder/src/build/index.ts
+++ b/packages/builder/src/build/index.ts
@@ -424,8 +424,16 @@ function getMetaMap(
 function getLinks(
   manifest: ViteManifest,
   srcFileName: string,
-  containSelf: boolean
+  containSelf: boolean,
+  cache = new Map()
 ): LinkDescriptor[] {
+
+  if (cache.has(srcFileName)) {
+    return [];
+  }
+
+  cache.set(srcFileName, true);
+
   const links: LinkDescriptor[] = [];
   const item = manifest[srcFileName];
   const push = (srcFileName: string) => {
@@ -450,7 +458,7 @@ function getLinks(
   if (Array.isArray(item.imports)) {
     item.imports?.forEach((srcFileName) => {
       links.push(
-        ...getLinks(manifest, srcFileName, true)
+        ...getLinks(manifest, srcFileName, true, cache)
           // Note: In the web router, all client components are loaded asynchronously.
           .filter((link) => link.rel !== "modulepreload")
       );
@@ -459,7 +467,7 @@ function getLinks(
 
   if (Array.isArray(item.dynamicImports)) {
     item.dynamicImports?.forEach((srcFileName) => {
-      links.push(...getLinks(manifest, srcFileName, true));
+      links.push(...getLinks(manifest, srcFileName, true, cache));
     });
   }
 


### PR DESCRIPTION
由于 `manifest.json` 中可能存在循环依赖的资产，这将会导致构建程序获取 meta 的时候无限递归的错误。