### PR TITLE
refactor: 提升 base 相关配置的健壮度

### DIFF
--- a/examples/examples/deno/main.ts
+++ b/examples/examples/deno/main.ts
@@ -5,14 +5,15 @@ import { Server } from "https://deno.land/std@0.196.0/http/mod.ts";
 // @ts-ignore
 import staticFiles from "https://deno.land/x/static_files@1.1.6/mod.ts";
 
+// @ts-ignore
 import WebRouter from "./dist/web-router.js";
+// @ts-ignore
+import routemap from "../dist/server/routemap.js";
 
-const webRouter = new WebRouter(
-  new URL("../dist/server/routemap.json", import.meta.url),
-  {
-    base: "/",
-  }
-);
+const webRouter = new WebRouter(routemap, {
+  baseAsset: "http://localhost:4505/",
+  baseModule: new URL("../dist/server/", import.meta.url),
+});
 
 const serveFiles = (req: Request) =>
   staticFiles("../dist/client")({

--- a/examples/examples/server.js
+++ b/examples/examples/server.js
@@ -19,7 +19,8 @@ app.use(async (ctx, next) => {
 });
 
 const webRouter = new WebRouter(routemap, {
-  base: "/",
+  baseAsset: "http://localhost:9000/",
+  baseModule: new URL("./dist/server/", import.meta.url),
   meta: {
     lang: "en",
     meta: [
@@ -35,9 +36,6 @@ const webRouter = new WebRouter(routemap, {
         content: "@web-widget/web-router",
       },
     ],
-  },
-  experimental: {
-    root: fileURLToPath(new URL("./", import.meta.url)),
   },
 });
 

--- a/examples/react-and-vue2/server.js
+++ b/examples/react-and-vue2/server.js
@@ -19,7 +19,8 @@ app.use(async (ctx, next) => {
 });
 
 const webRouter = new WebRouter(routemap, {
-  base: "/",
+  baseAsset: "http://localhost:9000/",
+  baseModule: new URL("./dist/server/", import.meta.url),
   meta: {
     lang: "en",
     meta: [
@@ -35,9 +36,6 @@ const webRouter = new WebRouter(routemap, {
         content: "@web-widget/web-router",
       },
     ],
-  },
-  experimental: {
-    root: fileURLToPath(new URL("./", import.meta.url)),
   },
 });
 

--- a/internal/eslint-config/src/index.ts
+++ b/internal/eslint-config/src/index.ts
@@ -20,9 +20,10 @@ export default defineConfig({
     },
   },
   env: {
-    browser: true,
+    browser: false,
+    worker: true,
     commonjs: false,
-    node: true,
+    node: false,
     es6: true,
   },
   settings: {

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/builder",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/schema",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/schema/src/helpers/meta.ts
+++ b/packages/schema/src/helpers/meta.ts
@@ -140,7 +140,7 @@ export function renderMetaToString(meta: Meta): string {
   return priority.flat().join("");
 }
 
-export function rebaseMeta(meta: Meta, base: string): Meta {
+export function rebaseMeta(meta: Meta, importer: string): Meta {
   const RESOLVE_URL_REG = /^(?:\w+:)?\//;
   return {
     ...meta,
@@ -149,7 +149,7 @@ export function rebaseMeta(meta: Meta, base: string): Meta {
       if (props.href && !RESOLVE_URL_REG.test(props.href)) {
         return {
           ...props,
-          href: base + props.href,
+          href: new URL(props.href, importer).href,
         };
       }
       return { ...props };
@@ -168,7 +168,7 @@ export function rebaseMeta(meta: Meta, base: string): Meta {
         const rebaseImports = (imports: Imports) =>
           Object.entries(imports).reduce((previousValue, [name, url]) => {
             if (!RESOLVE_URL_REG.test(url)) {
-              previousValue[name] = base + url;
+              previousValue[name] = new URL(url, importer).href;
             } else {
               previousValue[name] = url;
             }
@@ -183,7 +183,8 @@ export function rebaseMeta(meta: Meta, base: string): Meta {
               ? Object.entries(importmap.scopes).reduce(
                   (previousValue, [scope, imports]) => {
                     if (!RESOLVE_URL_REG.test(scope)) {
-                      previousValue[base + scope] = rebaseImports(imports);
+                      previousValue[new URL(scope, importer).href] =
+                        rebaseImports(imports);
                     } else {
                       previousValue[scope] = {};
                     }
@@ -199,7 +200,7 @@ export function rebaseMeta(meta: Meta, base: string): Meta {
       if (typeof props.src === "string" && !RESOLVE_URL_REG.test(props.src)) {
         return {
           ...props,
-          src: base + props.src,
+          src: new URL(props.src, importer).href,
         };
       }
 

--- a/packages/web-router/package.json
+++ b/packages/web-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/web-router",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/web-router/src/index.ts
+++ b/packages/web-router/src/index.ts
@@ -10,8 +10,8 @@ export type * from "./types";
 export default class WebRouter {
   #handler: RouterHandler;
 
-  constructor(routemap: string | URL | Manifest, opts: StartOptions = {}) {
-    const promise = ServerContext.fromManifest(routemap, opts, !!opts.dev).then(
+  constructor(manifest: Manifest, opts: StartOptions) {
+    const promise = ServerContext.fromManifest(manifest, opts, !!opts.dev).then(
       (serverContext) => {
         this.#handler = serverContext.handler();
         return serverContext;
@@ -33,6 +33,6 @@ export default class WebRouter {
    * e.g. `self.addEventListener('fetch', new WebRouter(manifest, options))`.
    */
   handleEvent(fetchEvent: FetchEvent) {
-    fetchEvent.respondWith(this.handler(fetchEvent.request, fetchEvent));
+    fetchEvent.respondWith(this.#handler(fetchEvent.request, fetchEvent));
   }
 }

--- a/packages/web-router/src/render.ts
+++ b/packages/web-router/src/render.ts
@@ -22,7 +22,7 @@ export interface InnerRenderOptions<Data> {
   meta: Meta;
   params: Record<string, string>;
   route: Page;
-  source: string;
+  source: URL;
   url: URL;
 }
 
@@ -33,7 +33,7 @@ export class InnerRenderContext {
   #id: string;
   #meta: Meta = {};
   #route: string;
-  #source: string;
+  #source: URL;
   #state: Map<string, unknown> = new Map();
   #url: URL;
 
@@ -42,7 +42,7 @@ export class InnerRenderContext {
     id: string,
     meta: Meta,
     route: string,
-    source: string,
+    source: URL,
     url: URL
   ) {
     this.#bootstrap = bootstrap;
@@ -86,7 +86,7 @@ export class InnerRenderContext {
     return this.#route;
   }
 
-  get source(): string {
+  get source(): URL {
     return this.#source;
   }
 }

--- a/packages/web-router/src/types.ts
+++ b/packages/web-router/src/types.ts
@@ -18,6 +18,8 @@ import type {
 } from "@web-widget/schema/server";
 import type { InnerRenderContext, InnerRenderFunction } from "./render";
 
+// --- MODULE ---
+
 export * from "@web-widget/schema/server";
 
 // --- APPLICATION CONFIGURATION ---
@@ -27,13 +29,13 @@ export type StartOptions = WebRouterOptions & {
 };
 
 export interface WebRouterOptions {
-  base?: string;
+  baseAsset: URL | string;
+  baseModule: URL | string;
   bootstrap?: ScriptDescriptor[];
   meta?: Meta;
   experimental?: {
-    loader?: (module: string) => Promise<any>;
+    loader?: (module: string, importer?: string) => Promise<unknown>;
     render?: RenderPage;
-    root?: string;
     router?: RouterOptions;
   };
 }
@@ -50,6 +52,67 @@ export type RenderPage = (
   ctx: InnerRenderContext,
   render: InnerRenderFunction
 ) => void | Promise<void>;
+
+export type RouterHandler = (
+  request: Request,
+  connInfo?: ConnectionInfo
+) => Response | Promise<Response>;
+
+// Information about the connection a request arrived on.
+export type ConnectionInfo = FetchEvent | unknown;
+
+// --- MANIFEST ---
+
+export type Manifest = ManifestResolved | ManifestJSON;
+
+export interface ManifestResolved {
+  routes?: {
+    module: RouteModule;
+    name?: string;
+    pathname: string;
+    source: string;
+  }[];
+  middlewares?: {
+    module: MiddlewareModule;
+    name?: string;
+    pathname: string;
+    source: string;
+  }[];
+  fallbacks?: {
+    module: RouteModule;
+    name: string;
+    pathname: string;
+    source: string;
+  }[];
+  layout?: {
+    module: LayoutModule;
+    source: string;
+    name?: string;
+  };
+}
+
+export interface ManifestJSON {
+  $schema?: string;
+  routes?: {
+    module: string;
+    name?: string;
+    pathname: string;
+  }[];
+  middlewares?: {
+    module: string;
+    name?: string;
+    pathname: string;
+  }[];
+  fallbacks?: {
+    module: string;
+    name: string;
+    pathname: string;
+  }[];
+  layout?: {
+    module: string;
+    name?: string;
+  };
+}
 
 // --- PAGE ---
 
@@ -78,7 +141,7 @@ export interface Page {
   name: string;
   pathname: string;
   render: RouteRender;
-  source: string;
+  source: URL;
 }
 
 // --- MIDDLEWARE ---
@@ -129,7 +192,7 @@ export interface Layout {
   module: LayoutModule;
   name: string;
   render: WidgetRender;
-  source: string;
+  source: URL;
 }
 
 export interface RootLayoutComponentProps {
@@ -137,68 +200,3 @@ export interface RootLayoutComponentProps {
   bootstrap: ScriptDescriptor[];
   meta: Meta;
 }
-
-// --- MANIFEST ---
-
-export interface Manifest {
-  $schema?: string;
-  routes?: (
-    | {
-        module: string;
-        name?: string;
-        pathname: string;
-      }
-    | {
-        module: RouteModule;
-        name?: string;
-        pathname: string;
-        source: string;
-      }
-  )[];
-  middlewares?: (
-    | {
-        module: string;
-        name?: string;
-        pathname: string;
-      }
-    | {
-        module: MiddlewareModule;
-        name?: string;
-        pathname: string;
-        source: string;
-      }
-  )[];
-  fallbacks?: (
-    | {
-        module: string;
-        name: string;
-        pathname: string;
-      }
-    | {
-        module: RouteModule;
-        name: string;
-        pathname: string;
-        source: string;
-      }
-  )[];
-  layout?:
-    | {
-        module: string;
-        name?: string;
-      }
-    | {
-        module: LayoutModule;
-        source: string;
-        name?: string;
-      };
-}
-
-// --- ROUTER ---
-
-export type RouterHandler = (
-  request: Request,
-  connInfo?: ConnectionInfo
-) => Response | Promise<Response>;
-
-// Information about the connection a request arrived on.
-export type ConnectionInfo = FetchEvent | unknown;


### PR DESCRIPTION
当前 PR 改进了 web-router 处理相对路径 Meta 转换逻辑健壮度。

* web-router 不再支持接受 json
* 删除了 web-router 的 `base` 与 `root` 选项，使用 `baseAsset` 与 `baseModule` 取代它们。
  * `baseAsset`: 它类似于 vite `base` 的配置，不同的是它只作用于静态资产。如果模块包含相对路径的 meta，web-router 将会根据 `baseAsset` 以及其模块的 URL 转换为绝对 URL
  * `baseModule`: 它用于确定 routemap.js 文件中的 `source` 绝对路径，类似于 vite `root` 配置，不同的是它只作用于构建后的资产

注意：`baseModule` 配置不稳定，未来可能会因为适应边缘计算环境的打包而产生变化。