### PR TITLE
feat: 支持用户配置 ssr 构建产物的 target

### DIFF
--- a/packages/builder/src/build/index.ts
+++ b/packages/builder/src/build/index.ts
@@ -110,7 +110,7 @@ async function bundleWithVite(
           format: "esm",
           //external: ["@web-server/web-router"],
           noExternal: true,
-          // target: "webworker",
+          target: config.vite.ssr?.target ?? "webworker",
         }
       : undefined,
     resolve: isServer


### PR DESCRIPTION
builder 在构建服务端代码的时候，默认输出为 worker 环境的产物，但有时候一些库无法支持 worker（例如 vue2），此时允许用户自己指定 `target` 使用 node 的产物。

```diff
// builder.config.ts
import { defineConfig } from "@web-widget/builder";
import vue from "@vitejs/plugin-vue";
import react from "@web-widget/react/vite-plugin";

export default defineConfig({
  input: "./routemap.json",
  vite: {
    ssr: {
+     target: "node"
    },
    plugins: [react(), vue()],
  },
});

```