### PR TITLE
refactor: 重构 web-router 选项

### DIFF
--- a/examples/examples/deno/main.ts
+++ b/examples/examples/deno/main.ts
@@ -13,6 +13,18 @@ import routemap from "../dist/server/routemap.js";
 const webRouter = new WebRouter(routemap, {
   baseAsset: "http://localhost:4505/",
   baseModule: new URL("../dist/server/", import.meta.url),
+  defaultMeta: {
+    lang: "en",
+    meta: [
+      {
+        charset: "utf-8",
+      },
+      {
+        name: "viewport",
+        content: "width=device-width, initial-scale=1.0",
+      },
+    ],
+  },
 });
 
 const serveFiles = (req: Request) =>

--- a/examples/examples/server.js
+++ b/examples/examples/server.js
@@ -21,7 +21,7 @@ app.use(async (ctx, next) => {
 const webRouter = new WebRouter(routemap, {
   baseAsset: "http://localhost:9000/",
   baseModule: new URL("./dist/server/", import.meta.url),
-  meta: {
+  defaultMeta: {
     lang: "en",
     meta: [
       {
@@ -30,10 +30,6 @@ const webRouter = new WebRouter(routemap, {
       {
         name: "viewport",
         content: "width=device-width, initial-scale=1.0",
-      },
-      {
-        "http-equiv": "X-Powered-By",
-        content: "@web-widget/web-router",
       },
     ],
   },

--- a/examples/react-and-vue2/server.js
+++ b/examples/react-and-vue2/server.js
@@ -21,7 +21,7 @@ app.use(async (ctx, next) => {
 const webRouter = new WebRouter(routemap, {
   baseAsset: "http://localhost:9000/",
   baseModule: new URL("./dist/server/", import.meta.url),
-  meta: {
+  defaultMeta: {
     lang: "en",
     meta: [
       {
@@ -30,10 +30,6 @@ const webRouter = new WebRouter(routemap, {
       {
         name: "viewport",
         content: "width=device-width, initial-scale=1.0",
-      },
-      {
-        "http-equiv": "X-Powered-By",
-        content: "@web-widget/web-router",
       },
     ],
   },

--- a/packages/web-router/src/context.ts
+++ b/packages/web-router/src/context.ts
@@ -106,14 +106,14 @@ export class ServerContext {
     const resolvedOpts = {
       baseAsset: isDevBaseAsset ? opts.baseAsset : new URL(opts.baseAsset).href,
       baseModule: new URL(opts.baseModule).href,
-      bootstrap: opts.bootstrap ?? DEFAULT_BOOTSTRAP,
+      bootstrap: opts.defaultBootstrap ?? DEFAULT_BOOTSTRAP,
       loader:
         opts.experimental?.loader ??
         ((module: string, importer?: string) => {
           const url = new URL(module, importer).href;
           return import(/* @vite-ignore */ /* webpackIgnore: true */ url);
         }),
-      meta: opts.meta ?? DEFAULT_META,
+      meta: opts.defaultMeta ?? DEFAULT_META,
       render: opts.experimental?.render ?? DEFAULT_RENDER_FN,
       router: opts.experimental?.router ?? DEFAULT_ROUTER_OPTIONS,
     };

--- a/packages/web-router/src/types.ts
+++ b/packages/web-router/src/types.ts
@@ -31,8 +31,8 @@ export type StartOptions = WebRouterOptions & {
 export interface WebRouterOptions {
   baseAsset: URL | string;
   baseModule: URL | string;
-  bootstrap?: ScriptDescriptor[];
-  meta?: Meta;
+  defaultBootstrap?: ScriptDescriptor[];
+  defaultMeta?: Meta;
   experimental?: {
     loader?: (module: string, importer?: string) => Promise<unknown>;
     render?: RenderPage;


### PR DESCRIPTION
为了让语义更清晰，选项名变更：

* `meta` -> `defaultMeta`
* `bootstrap` -> `defaultBootstrap`