### PR TITLE
feat: 中间件可访问  Requester 对象

### DIFF
--- a/examples/examples/deno/main.ts
+++ b/examples/examples/deno/main.ts
@@ -36,12 +36,12 @@ const serveFiles = (req: Request) =>
 const port = 4505;
 const server = new Server({
   port,
-  handler: async (request: Request, connInfo: ConnInfo) => {
+  handler: async (request: Request, requester: ConnInfo) => {
     if (new URL(request.url).pathname.startsWith("/assets")) {
       return serveFiles(request);
     }
 
-    return webRouter.handler(request, connInfo);
+    return webRouter.handler(request, requester);
   },
 });
 

--- a/packages/web-router/src/context.ts
+++ b/packages/web-router/src/context.ts
@@ -17,16 +17,16 @@ import * as router from "./router";
 import * as defaultRootFallbackModule from "./fallback";
 import * as defaultRootLayoutModule from "./layout";
 import type {
-  ConnectionInfo,
-  LayoutRender,
   Layout,
   LayoutModule,
+  LayoutRender,
   Manifest,
   Middleware,
   MiddlewareHandlerContext,
   MiddlewareModule,
   Page,
   RenderPage,
+  Requester,
   RouterHandler,
   RouterOptions,
   ScriptDescriptor,
@@ -309,7 +309,7 @@ export class ServerContext {
     const trailingSlashEnabled = this.#routerOptions?.trailingSlash;
     return async function handler(
       req: Request,
-      _connInfo?: ConnectionInfo
+      requester?: Requester
     ): Promise<Response> {
       // Redirect requests that end with a trailing slash to their non-trailing
       // slash counterpart.
@@ -331,7 +331,7 @@ export class ServerContext {
         return Response.redirect(url.href + "/", HttpStatus.PermanentRedirect);
       }
 
-      return await withMiddlewares(req, inner, _connInfo);
+      return await withMiddlewares(req, inner, requester);
     };
   }
 
@@ -346,7 +346,7 @@ export class ServerContext {
     return (
       req: Request,
       inner: router.FinalHandler<RouterState>,
-      _connInfo?: ConnectionInfo
+      requester?: Requester
     ) => {
       // identify middlewares to apply, if any.
       // middlewares should be already sorted from deepest to shallow layer
@@ -355,7 +355,7 @@ export class ServerContext {
       const handlers: (() => Response | Promise<Response>)[] = [];
 
       const middlewareCtx: MiddlewareHandlerContext = {
-        _connInfo,
+        requester,
         destination: "route",
         request: req,
         state: {},
@@ -377,7 +377,7 @@ export class ServerContext {
       }
 
       const ctx = {
-        _connInfo,
+        requester,
         request: req,
         state: middlewareCtx.state,
       };

--- a/packages/web-router/src/index.ts
+++ b/packages/web-router/src/index.ts
@@ -1,10 +1,5 @@
 import { ServerContext } from "./context";
-import type {
-  StartOptions,
-  RouterHandler,
-  ConnectionInfo,
-  Manifest,
-} from "./types";
+import type { Manifest, Requester, RouterHandler, StartOptions } from "./types";
 export type * from "./types";
 
 export default class WebRouter {
@@ -19,9 +14,9 @@ export default class WebRouter {
       }
     );
 
-    this.#handler = async (req: Request, info?: ConnectionInfo) => {
+    this.#handler = async (req: Request, requester?: Requester) => {
       const serverContext = await promise;
-      return serverContext.handler()(req, info);
+      return serverContext.handler()(req, requester);
     };
     this.#options = opts;
   }

--- a/packages/web-router/src/types.ts
+++ b/packages/web-router/src/types.ts
@@ -56,11 +56,11 @@ export type RenderPage = (
 
 export type RouterHandler = (
   request: Request,
-  connInfo?: ConnectionInfo
+  requester?: Requester
 ) => Response | Promise<Response>;
 
 // Information about the connection a request arrived on.
-export type ConnectionInfo = FetchEvent | unknown;
+export type Requester = FetchEvent | unknown;
 
 // --- MANIFEST ---
 
@@ -157,9 +157,9 @@ export type MiddlewareHandler<State = Record<string, unknown>> = (
 ) => Response | Promise<Response>;
 
 export interface MiddlewareHandlerContext<State = Record<string, unknown>> {
-  _connInfo?: ConnectionInfo;
   destination: router.DestinationKind;
   request: Request;
+  requester?: Requester;
   state: State;
 }
 


### PR DESCRIPTION
由于 WebRouter 被设计为可以兼容其他服务器运行的库，因此 `Requester` 被设计为记录服务端连接信息，以便给中间件处理更底层的业务逻辑。

```ts
type RouterHandler = (
  request: Request,
  requester?: Requester
) => Response | Promise<Response>;
```

根据不同服务器环境，`Requester` 可能的值：

* Worker 环境：[`FetchEvent`](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent)
* Deno 环境：[`ConnInfo`](https://deno.land/std@0.196.0/http/mod.ts?s=ConnInfo)
* Node.js 环境：[`FetchEvent`](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent)（使用 @web-widget/node 适配器后）