### PR TITLE
feat: 支持开发者为 vue 实例注入插件

### DIFF
--- a/packages/vue/src/client.ts
+++ b/packages/vue/src/client.ts
@@ -4,8 +4,14 @@ import { createApp, createSSRApp } from "vue";
 import { defineRender } from "@web-widget/schema/client-helpers";
 
 export * from "@web-widget/schema/client-helpers";
-export const render = defineRender(
-  async ({ recovering, container }, component, props) => {
+export interface DefineVueRenderOptions {
+  onCreatedApp?: (app: App) => void;
+}
+
+export const defineVueRender = ({
+  onCreatedApp = () => {},
+}: DefineVueRenderOptions = {}) => {
+  return defineRender(async ({ recovering, container }, component, props) => {
     if (!container) {
       throw new Error(`Container required.`);
     }
@@ -18,6 +24,7 @@ export const render = defineRender(
         } else {
           app = createApp(component, props as Record<string, any>);
         }
+        onCreatedApp(app);
         app.mount(container);
       },
 
@@ -26,5 +33,7 @@ export const render = defineRender(
         app = null;
       },
     };
-  }
-);
+  });
+};
+
+export const render = defineVueRender();

--- a/packages/vue/src/server.ts
+++ b/packages/vue/src/server.ts
@@ -1,9 +1,21 @@
+import type { App } from "vue";
 import { createSSRApp } from "vue";
 import { defineRender } from "@web-widget/schema/server-helpers";
 import { renderToWebStream } from "vue/server-renderer";
 
 export * from "@web-widget/schema/server-helpers";
-export const render = defineRender(async (context, component, props) => {
-  const app = createSSRApp(component, props as Record<string, any>);
-  return renderToWebStream(app);
-});
+export interface DefineVueRenderOptions {
+  onCreatedApp?: (app: App) => void;
+}
+
+export const defineVueRender = ({
+  onCreatedApp = () => {},
+}: DefineVueRenderOptions = {}) => {
+  return defineRender(async (context, component, props) => {
+    const app = createSSRApp(component, props as Record<string, any>);
+    onCreatedApp(app);
+    return renderToWebStream(app);
+  });
+};
+
+export const render = defineVueRender();

--- a/packages/vue2/src/client.ts
+++ b/packages/vue2/src/client.ts
@@ -1,34 +1,50 @@
 import Vue from "vue";
-import { defineRender } from "@web-widget/schema/client-helpers";
+import { defineRender as defineRenderHelper } from "@web-widget/schema/client-helpers";
 
 export * from "@web-widget/schema/client-helpers";
-export const render = defineRender(
-  async ({ recovering, container }, component, props) => {
-    if (!container) {
-      throw new Error(`Container required.`);
+export interface DefineVueRenderOptions {
+  onBeforeCreateApp?: () => any;
+  onCreatedApp?: (app: Vue) => void;
+}
+
+export const defineVueRender = ({
+  onBeforeCreateApp = () => ({}),
+  onCreatedApp = () => {},
+}: DefineVueRenderOptions = {}) => {
+  return defineRenderHelper(
+    async ({ recovering, container }, component, props) => {
+      if (!container) {
+        throw new Error(`Container required.`);
+      }
+
+      let app: Vue | null;
+      return {
+        async mount() {
+          const shell =
+            (recovering
+              ? container.querySelector("[data-vue2-shell]")
+              : null) || container.appendChild(document.createElement("div"));
+
+          app = new Vue({
+            ...onBeforeCreateApp(),
+            render(h) {
+              return h(component, props as Record<string, any>);
+            },
+          });
+
+          onCreatedApp(app);
+
+          app.$mount(shell);
+        },
+
+        async unmount() {
+          app?.$destroy();
+          container.innerHTML = "";
+          app = null;
+        },
+      };
     }
+  );
+};
 
-    let app: Vue | null;
-    return {
-      async mount() {
-        const shell =
-          (recovering ? container.querySelector("[data-vue2-shell]") : null) ||
-          container.appendChild(document.createElement("div"));
-
-        app = new Vue({
-          render(h) {
-            return h(component, props as Record<string, any>);
-          },
-        });
-
-        app.$mount(shell);
-      },
-
-      async unmount() {
-        app?.$destroy();
-        container.innerHTML = "";
-        app = null;
-      },
-    };
-  }
-);
+export const render = defineVueRender();

--- a/packages/vue2/src/server.ts
+++ b/packages/vue2/src/server.ts
@@ -4,15 +4,29 @@ import { createRenderer } from "@web-widget/vue-server-renderer/build.prod.js";
 import { defineRender } from "@web-widget/schema/server-helpers";
 
 export * from "@web-widget/schema/server-helpers";
-export const render = defineRender(async (context, component, props) => {
-  const renderer = createRenderer();
-  const app = new Vue({
-    render(h) {
-      return h(component, props as Record<string, any>);
-    },
-  });
+export interface DefineVueRenderOptions {
+  onBeforeCreateApp?: () => any;
+  onCreatedApp?: (app: Vue) => void;
+}
 
-  // TODO renderer.renderToStream() to ReadableStream
-  const content = await renderer.renderToString(app);
-  return `<div data-vue2-shell>` + content + "</div>";
-});
+export const defineVueRender = ({
+  onBeforeCreateApp = () => ({}),
+  onCreatedApp = () => {},
+}: DefineVueRenderOptions = {}) => {
+  return defineRender(async (context, component, props) => {
+    const renderer = createRenderer();
+    const app = new Vue({
+      ...onBeforeCreateApp(),
+      render(h) {
+        return h(component, props as Record<string, any>);
+      },
+    });
+
+    onCreatedApp(app);
+
+    const content = await renderer.renderToString(app);
+    return `<div data-vue2-shell>` + content + "</div>";
+  });
+};
+
+export const render = defineVueRender();


### PR DESCRIPTION
使用方式：

```ts
import { defineVueRender } from "@web-widget/vue2"

export const render = defineVueRender({
  onBeforeCreateApp() {
    return {
      // Vue options
    }
  },
  onCreatedApp(app) {}
});
```