### PR TITLE
feat: 输出routemap.js时，同时输出routemap.d.ts

### DIFF
--- a/packages/builder/src/build/index.ts
+++ b/packages/builder/src/build/index.ts
@@ -601,6 +601,8 @@ export async function buildRoutemap(
       `new URL("./", import.meta.url).href`
     )*/
 
+  const definitionCode = `import type { Manifest } from '@web-widget/web-router';\nexport default {} as Manifest`;
+
   await Promise.all([
     fs.writeFile(
       join(
@@ -615,6 +617,13 @@ export async function buildRoutemap(
         basename(input.replace(extname(input), ".js"))
       ),
       jsCode
+    ),
+    fs.writeFile(
+      join(
+        fileURLToPath(config.output.server),
+        basename(input.replace(extname(input), ".d.ts"))
+      ),
+      definitionCode
     ),
   ]);
 }


### PR DESCRIPTION
为 routemap.js 生成 ts类型定义文件，解决ts下import报错
![image](https://github.com/web-widget/web-widget/assets/28132598/7c9c0458-55ed-40ed-9fef-0ad396bdf97b)
![image](https://github.com/web-widget/web-widget/assets/28132598/33d737e6-1487-4c1c-860f-39b9e15ca7fa)
