### PR TITLE
refactor: 增强 vue2 渲染器的定义能力 #137

### DIFF
--- a/packages/schema/src/helpers/client.ts
+++ b/packages/schema/src/helpers/client.ts
@@ -37,6 +37,7 @@ export type {
   ComponentProps,
   Component,
   Meta,
+  ClientRenderContext as RenderContext,
   ClientRender as Render,
   HttpError,
 } from "../types";

--- a/packages/schema/src/helpers/server.ts
+++ b/packages/schema/src/helpers/server.ts
@@ -37,6 +37,7 @@ export type {
   ComponentProps,
   Component,
   Meta,
+  ServerRenderContext as RenderContext,
   ServerRender as Render,
   HttpError,
 } from "../types";

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -474,6 +474,18 @@ export interface Meta {
   title?: string;
 }
 
+export type RenderContext<Data = unknown> =
+  | ServerRenderContext<Data>
+  | ClientRenderContext<Data>;
+
+export type ServerRenderContext<Data = unknown> =
+  | ServerWidgetRenderContext<Data>
+  | ServerRouteRenderContext<Data>;
+
+export type ClientRenderContext<Data = unknown> =
+  | ClientWidgetRenderContext<Data>
+  | ClientRouteRenderContext<Data>;
+
 export type Render<Data = unknown> = ServerRender<Data> | ClientRender<Data>;
 
 export type ServerRender<Data = unknown> =

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/vue",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/vue/src/server.ts
+++ b/packages/vue/src/server.ts
@@ -1,19 +1,29 @@
-import type { App } from "vue";
+import type { App, Component } from "vue";
 import { createSSRApp } from "vue";
+import type {
+  ComponentProps,
+  RenderContext,
+} from "@web-widget/schema/server-helpers";
 import { defineRender } from "@web-widget/schema/server-helpers";
 import { renderToWebStream } from "vue/server-renderer";
 
 export * from "@web-widget/schema/server-helpers";
 export interface DefineVueRenderOptions {
-  onCreatedApp?: (app: App) => void;
+  onCreatedApp?: (
+    app: App,
+    context: RenderContext,
+    component: Component,
+    props: ComponentProps
+  ) => void;
 }
 
 export const defineVueRender = ({
   onCreatedApp = () => {},
 }: DefineVueRenderOptions = {}) => {
   return defineRender(async (context, component, props) => {
-    const app = createSSRApp(component, props as Record<string, any>);
-    onCreatedApp(app);
+    const rootProps = props as Record<string, any>;
+    const app = createSSRApp(component, rootProps);
+    onCreatedApp(app, context, component, props);
     return renderToWebStream(app);
   });
 };

--- a/packages/vue2/package.json
+++ b/packages/vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/vue2",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/vue2/src/server.dev.ts
+++ b/packages/vue2/src/server.dev.ts
@@ -1,12 +1,25 @@
 import Vue from "vue";
 // @ts-ignore
 import { createRenderer } from "vue-server-renderer/build.dev.js";
+import type {
+  ComponentProps,
+  RenderContext,
+} from "@web-widget/schema/server-helpers";
 import { defineRender } from "@web-widget/schema/server-helpers";
 
 export * from "@web-widget/schema/server-helpers";
 export interface DefineVueRenderOptions {
-  onBeforeCreateApp?: () => any;
-  onCreatedApp?: (app: Vue) => void;
+  onBeforeCreateApp?: (
+    context: RenderContext,
+    component: Vue.Component,
+    props: ComponentProps
+  ) => any;
+  onCreatedApp?: (
+    app: Vue,
+    context: RenderContext,
+    component: Vue.Component,
+    props: ComponentProps
+  ) => void;
 }
 
 export const defineVueRender = ({
@@ -14,15 +27,18 @@ export const defineVueRender = ({
   onCreatedApp = () => {},
 }: DefineVueRenderOptions = {}) => {
   return defineRender(async (context, component, props) => {
+    const vNodeData: Vue.VNodeData = {
+      props: props as Record<string, any>,
+    };
     const renderer = createRenderer();
     const app = new Vue({
-      ...onBeforeCreateApp(),
       render(h) {
-        return h(component, props as Record<string, any>);
+        return h(component, vNodeData);
       },
+      ...onBeforeCreateApp(context, component, props),
     });
 
-    onCreatedApp(app);
+    onCreatedApp(app, context, component, props);
 
     const content = await renderer.renderToString(app);
     return `<div data-vue2-shell>` + content + "</div>";

--- a/packages/vue2/src/server.ts
+++ b/packages/vue2/src/server.ts
@@ -1,12 +1,25 @@
 import Vue from "vue";
 // @ts-ignore
 import { createRenderer } from "vue-server-renderer/build.prod.js";
+import type {
+  ComponentProps,
+  RenderContext,
+} from "@web-widget/schema/server-helpers";
 import { defineRender } from "@web-widget/schema/server-helpers";
 
 export * from "@web-widget/schema/server-helpers";
 export interface DefineVueRenderOptions {
-  onBeforeCreateApp?: () => any;
-  onCreatedApp?: (app: Vue) => void;
+  onBeforeCreateApp?: (
+    context: RenderContext,
+    component: Vue.Component,
+    props: ComponentProps
+  ) => any;
+  onCreatedApp?: (
+    app: Vue,
+    context: RenderContext,
+    component: Vue.Component,
+    props: ComponentProps
+  ) => void;
 }
 
 export const defineVueRender = ({
@@ -14,15 +27,18 @@ export const defineVueRender = ({
   onCreatedApp = () => {},
 }: DefineVueRenderOptions = {}) => {
   return defineRender(async (context, component, props) => {
+    const vNodeData: Vue.VNodeData = {
+      props: props as Record<string, any>,
+    };
     const renderer = createRenderer();
     const app = new Vue({
-      ...onBeforeCreateApp(),
       render(h) {
-        return h(component, props as Record<string, any>);
+        return h(component, vNodeData);
       },
+      ...onBeforeCreateApp(context, component, props),
     });
 
-    onCreatedApp(app);
+    onCreatedApp(app, context, component, props);
 
     const content = await renderer.renderToString(app);
     return `<div data-vue2-shell>` + content + "</div>";


### PR DESCRIPTION
* vue2、vue3 渲染器可以通过 `onBeforeCreateApp` 获取到 `context`
* 修复 vue2 渲染器没有正确处理 props 的问题