### PR TITLE
refactor: 分离 RouteModule 与 WidgetModule 的关键构建插件

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/builder",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "exports": {
     ".": {
@@ -20,10 +20,12 @@
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
+    "@rollup/pluginutils": "^5.0.3",
     "@web-widget/node": "workspace:*",
     "builtin-modules": "^3.3.0",
     "es-module-lexer": "^1.3.0 ",
     "import-meta-resolve": "^3.0.0",
+    "magic-string": "^0.30.2",
     "mico-spinner": "^1.4.0",
     "mime-types": "^2.1.35",
     "minimist": "^1.2.5",

--- a/packages/builder/src/build/injection-meta.ts
+++ b/packages/builder/src/build/injection-meta.ts
@@ -1,0 +1,206 @@
+import type { LinkDescriptor, ScriptDescriptor } from "@web-widget/schema";
+import * as esModuleLexer from "es-module-lexer";
+import type {
+  Manifest as ViteManifest,
+  Plugin as VitePlugin,
+  ResolvedConfig as ViteResolvedConfig,
+} from "vite";
+import { extname, relative } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import mime from "mime-types";
+import { createFilter, type FilterPattern } from "@rollup/pluginutils";
+import MagicString from "magic-string";
+import { resolve } from "import-meta-resolve";
+
+export type InjectionMetaPluginOptions = {
+  manifest: ViteManifest;
+  include?: FilterPattern;
+  exclude?: FilterPattern;
+};
+
+export default function injectionMetaPlugin({
+  manifest,
+  include,
+  exclude,
+}: InjectionMetaPluginOptions): VitePlugin {
+  let config: ViteResolvedConfig;
+  const CLIENT_MODULE_NAME = "@web-widget/web-widget";
+  const RESOLVE_URL_REG = /^(?:\w+:)?\//;
+  const filter = createFilter(include, exclude);
+  const rebase = (src: string, importer: string) => {
+    //return relative(dirname(importer), src);
+    return RESOLVE_URL_REG.test(src) ? src : config.base + src;
+  };
+
+  return {
+    name: "builder:injection-meta",
+    enforce: "post",
+    configResolved(resolvedConfig) {
+      config = resolvedConfig;
+    },
+    async transform(code, id) {
+      if (!filter(id)) {
+        return null;
+      }
+
+      const webWidgetResolvedId = fileURLToPath(
+        resolve(CLIENT_MODULE_NAME, pathToFileURL(id).href)
+      );
+      const webWidgetFileName = webWidgetResolvedId
+        ? relative(config.root, webWidgetResolvedId)
+        : null;
+      const magicString = new MagicString(code);
+      const fileName = relative(config.root, id);
+      const meta = {
+        script: webWidgetResolvedId
+          ? [
+              {
+                type: "importmap",
+                content: JSON.stringify({
+                  imports: {
+                    [CLIENT_MODULE_NAME]: rebase(
+                      manifest[webWidgetFileName as string].file,
+                      id
+                    ),
+                  },
+                }),
+              } as ScriptDescriptor,
+            ]
+          : [],
+        link: [
+          ...(webWidgetResolvedId
+            ? getLinks(manifest, webWidgetFileName as string, true)
+            : []),
+          ...getLinks(manifest, fileName, false),
+        ].map(({ href, ...attrs }) => {
+          if (href) {
+            return {
+              ...attrs,
+              href: rebase(href, id),
+            };
+          } else {
+            return attrs;
+          }
+        }),
+      };
+
+      await esModuleLexer.init;
+      const [, exports] = esModuleLexer.parse(code, fileName);
+
+      if (exports.some(({ n }) => n === "meta")) {
+        magicString.append(
+          [
+            `try {`,
+            `  const link = ${JSON.stringify(meta.link, null, 2)};`,
+            `  const script = ${JSON.stringify(meta.script, null, 2)};`,
+            `  meta.link ? meta.link.push(...link) : (meta.link = link);`,
+            `  meta.script ? meta.script.push(...script) : (meta.script = script);`,
+            `} catch(e) {`,
+            `  throw new Error("@web-widget/builder: Failed to attach meta.", e);`,
+            `}`,
+          ].join("\n")
+        );
+      } else {
+        magicString.append(
+          [
+            ``,
+            `export const meta = {`,
+            `  link: ${JSON.stringify(meta.link)},`,
+            `  script: ${JSON.stringify(meta.script)},`,
+            `};`,
+          ].join("\n")
+        );
+      }
+
+      return { code: magicString.toString(), map: magicString.generateMap() };
+    },
+  };
+}
+
+function getLinks(
+  manifest: ViteManifest,
+  srcFileName: string,
+  containSelf: boolean,
+  cache = new Map()
+): LinkDescriptor[] {
+  if (cache.has(srcFileName)) {
+    return [];
+  }
+
+  cache.set(srcFileName, true);
+
+  const links: LinkDescriptor[] = [];
+  const item = manifest[srcFileName];
+
+  if (!item) {
+    return [];
+  }
+
+  const push = (srcFileName: string) => {
+    const ld = getLink(srcFileName);
+    if (ld) {
+      links.push(ld);
+    }
+  };
+
+  if (containSelf) {
+    push(item.file);
+  }
+
+  if (Array.isArray(item.assets)) {
+    item.assets.forEach(push);
+  }
+
+  if (Array.isArray(item.css)) {
+    item.css.forEach(push);
+  }
+
+  if (Array.isArray(item.imports)) {
+    item.imports?.forEach((srcFileName) => {
+      links.push(
+        ...getLinks(manifest, srcFileName, true, cache)
+          // Note: In the web router, all client components are loaded asynchronously.
+          .filter((link) => link.rel !== "modulepreload")
+      );
+    });
+  }
+
+  if (Array.isArray(item.dynamicImports)) {
+    item.dynamicImports?.forEach((srcFileName) => {
+      links.push(...getLinks(manifest, srcFileName, true, cache));
+    });
+  }
+
+  return links;
+}
+
+function getLink(fileName: string): LinkDescriptor | null {
+  if (fileName.endsWith(".js")) {
+    return {
+      crossorigin: "",
+      href: fileName,
+      rel: "modulepreload",
+    };
+  } else if (fileName.endsWith(".css")) {
+    return {
+      href: fileName,
+      rel: "stylesheet",
+    };
+  }
+
+  const ext = extname(fileName);
+  const type = mime.lookup(ext);
+  const asValue = type ? type.split("/")[0] : "";
+
+  if (type && ["image", "font"].includes(asValue)) {
+    return {
+      as: asValue,
+      ...(asValue === "font" ? { crossorigin: "" } : {}),
+      href: fileName,
+      rel: "preload",
+      type,
+    };
+  }
+
+  return null;
+}

--- a/packages/builder/src/build/replace-asset.ts
+++ b/packages/builder/src/build/replace-asset.ts
@@ -1,0 +1,68 @@
+import type { Manifest as ViteManifest, Plugin as VitePlugin } from "vite";
+import { createFilter, type FilterPattern } from "@rollup/pluginutils";
+import MagicString from "magic-string";
+
+export type ReplaceAssetPluginOptions = {
+  manifest: ViteManifest;
+  include?: FilterPattern;
+  exclude?: FilterPattern;
+};
+
+export default function replaceAssetPlugin({
+  manifest,
+  include,
+  exclude,
+}: ReplaceAssetPluginOptions): VitePlugin {
+  let extensions: string[] = [];
+  let base: string;
+  const filter = createFilter(include, exclude);
+  const ASSET_PLACEHOLDER_REG = /(["'`])asset:\/\/(.*?)\1/g;
+  return {
+    name: "builder:replace-asset-placeholder",
+    enforce: "post",
+    configResolved(resolvedConfig) {
+      base = resolvedConfig.base;
+      extensions = resolvedConfig.resolve.extensions;
+    },
+    async transform(code, id) {
+      if (!filter(id)) {
+        return null;
+      }
+      // const normalize = (file: string) => {
+      //   return !/^\.+\//.test(file) ? "./" + file : file;
+      // };
+
+      const magicString = new MagicString(code);
+
+      magicString.replace(
+        ASSET_PLACEHOLDER_REG,
+        (match, quotation, fileName) => {
+          if (!fileName) {
+            return match;
+          }
+
+          let asset = manifest[fileName];
+
+          if (!asset) {
+            const extension = extensions.find(
+              (extension) => manifest[fileName + extension]
+            );
+            if (extension) {
+              asset = manifest[fileName + extension];
+            }
+          }
+
+          if (!asset) {
+            throw new Error(
+              `Asset not found in client build manifest: "${fileName}". From: ${id}`
+            );
+          }
+
+          return quotation + base + asset.file + quotation;
+        }
+      );
+
+      return { code: magicString.toString(), map: magicString.generateMap() };
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
 
   packages/builder:
     dependencies:
+      '@rollup/pluginutils':
+        specifier: ^5.0.3
+        version: 5.0.3(rollup@3.23.0)
       '@web-widget/node':
         specifier: workspace:*
         version: link:../node
@@ -272,6 +275,9 @@ importers:
       import-meta-resolve:
         specifier: ^3.0.0
         version: 3.0.0
+      magic-string:
+        specifier: ^0.30.2
+        version: 0.30.2
       mico-spinner:
         specifier: ^1.4.0
         version: 1.4.0
@@ -3190,7 +3196,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.3(rollup@3.25.1)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
@@ -3208,7 +3214,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.3(rollup@3.25.1)
       rollup: 3.25.1
     dev: true
 
@@ -3251,7 +3257,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.3(rollup@3.25.1)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-builtin-module: 3.2.1
@@ -3279,7 +3285,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.3(rollup@3.25.1)
       magic-string: 0.27.0
       rollup: 3.25.1
     dev: true
@@ -3296,8 +3302,8 @@ packages:
       rollup: 2.79.1
     dev: true
 
-  /@rollup/pluginutils@5.0.2(rollup@2.79.1):
-    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+  /@rollup/pluginutils@5.0.3(rollup@2.79.1):
+    resolution: {integrity: sha512-hfllNN4a80rwNQ9QCxhxuHCGHMAvabXqxNdaChUSSadMre7t4iEUI6fFAhBOn/eIYTgYVhBv7vCLsAJ4u3lf3g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0
@@ -3311,8 +3317,23 @@ packages:
       rollup: 2.79.1
     dev: true
 
-  /@rollup/pluginutils@5.0.2(rollup@3.25.1):
-    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+  /@rollup/pluginutils@5.0.3(rollup@3.23.0):
+    resolution: {integrity: sha512-hfllNN4a80rwNQ9QCxhxuHCGHMAvabXqxNdaChUSSadMre7t4iEUI6fFAhBOn/eIYTgYVhBv7vCLsAJ4u3lf3g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.1
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 3.23.0
+    dev: false
+
+  /@rollup/pluginutils@5.0.3(rollup@3.25.1):
+    resolution: {integrity: sha512-hfllNN4a80rwNQ9QCxhxuHCGHMAvabXqxNdaChUSSadMre7t4iEUI6fFAhBOn/eIYTgYVhBv7vCLsAJ4u3lf3g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0
@@ -3510,7 +3531,6 @@ packages:
 
   /@types/estree@1.0.1:
     resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
-    dev: true
 
   /@types/express-serve-static-core@4.17.35:
     resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==}
@@ -4004,7 +4024,7 @@ packages:
       '@vue/reactivity-transform': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.0
+      magic-string: 0.30.2
       postcss: 8.4.24
       source-map-js: 1.0.2
 
@@ -4021,7 +4041,7 @@ packages:
       '@vue/compiler-core': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.0
+      magic-string: 0.30.2
 
   /@vue/reactivity@3.3.4:
     resolution: {integrity: sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==}
@@ -4228,9 +4248,9 @@ packages:
     resolution: {integrity: sha512-lLIzsd94SwQv/z4eOhOECCTzQBZRT20wmmAQaP/wFJZfRgQNWaf3SxMClRlmw1Kuo2x6LdSXocnocUyKcmKNOg==}
     engines: {node: '>=10.0.0'}
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@2.79.1)
+      '@rollup/pluginutils': 5.0.3(rollup@2.79.1)
       estree-walker: 2.0.2
-      magic-string: 0.30.0
+      magic-string: 0.30.2
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -9354,8 +9374,8 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /magic-string@0.30.0:
-    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
+  /magic-string@0.30.2:
+    resolution: {integrity: sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -11850,7 +11870,7 @@ packages:
       rollup: ^3.0.0
       typescript: ^4.1 || ^5.0
     dependencies:
-      magic-string: 0.30.0
+      magic-string: 0.30.2
       rollup: 3.25.1
       typescript: 5.1.6
     optionalDependencies:
@@ -11905,7 +11925,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /rollup@3.25.1:
     resolution: {integrity: sha512-tywOR+rwIt5m2ZAWSe5AIJcTat8vGlnPFAv15ycCrw33t6iFsXZ6mzHVFh2psSjxQPmI+xgzMZZizUAukBI4aQ==}
@@ -13167,7 +13186,7 @@ packages:
       '@rollup/plugin-json': 6.0.0(rollup@3.25.1)
       '@rollup/plugin-node-resolve': 15.1.0(rollup@3.25.1)
       '@rollup/plugin-replace': 5.0.2(rollup@3.25.1)
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.3(rollup@3.25.1)
       chalk: 5.3.0
       consola: 3.2.3
       defu: 6.1.2
@@ -13175,7 +13194,7 @@ packages:
       globby: 13.2.2
       hookable: 5.5.3
       jiti: 1.19.1
-      magic-string: 0.30.0
+      magic-string: 0.30.2
       mkdist: 1.3.0(typescript@5.1.6)
       mlly: 1.4.0
       mri: 1.2.0


### PR DESCRIPTION
为接下来定义 `\.route\.(m?js|tsx?|vue)` 与 `\.widget\.(m?js|tsx?|vue)` 模块格式约定做准备。