### PR TITLE
fix: The content of the style tag was unexpectedly escaped

### DIFF
--- a/examples/full/CHANGELOG.md
+++ b/examples/full/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @examples/full
 
+## 1.0.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @web-widget/schema@0.1.2
+  - @web-widget/html@0.1.2
+  - @web-widget/react@0.3.2
+  - @web-widget/vue@0.4.2
+  - @web-widget/web-router@0.4.2
+  - @web-widget/web-widget@1.0.1
+
 ## 1.0.8
 
 ### Patch Changes

--- a/examples/full/css/base-layout.css
+++ b/examples/full/css/base-layout.css
@@ -15,7 +15,7 @@ header {
   border-bottom: rgba(60, 60, 60, 0.12) solid 1px;
 }
 
-header h1 {
+header > h1 {
   padding-left: 40px;
   padding-right: 40px;
 }

--- a/examples/full/package.json
+++ b/examples/full/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/full",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "description": "",
   "keywords": [],

--- a/examples/vue2/CHANGELOG.md
+++ b/examples/vue2/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @examples/vue2
 
+## 1.0.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @web-widget/schema@0.1.2
+  - @web-widget/html@0.1.2
+  - @web-widget/react@0.3.2
+  - @web-widget/vue2@0.2.2
+  - @web-widget/web-router@0.4.2
+  - @web-widget/web-widget@1.0.1
+
 ## 1.0.10
 
 ### Patch Changes

--- a/examples/vue2/package.json
+++ b/examples/vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/vue2",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "type": "module",
   "private": true,
   "description": "",

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @web-widget/html
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @web-widget/schema@0.1.2
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/html",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @web-widget/react
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @web-widget/schema@0.1.2
+  - @web-widget/vite@2.0.2
+  - @web-widget/web-widget@1.0.1
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/react",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @web-widget/schema
 
+## 0.1.2
+
+### Patch Changes
+
+- fix: The content of the style tag was unexpectedly escaped.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/schema",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/schema/src/helpers/utils.ts
+++ b/packages/schema/src/helpers/utils.ts
@@ -1,0 +1,63 @@
+/*!
+ * escape-html
+ * https://github.com/component/escape-html/blob/master/index.js
+ * Copyright(c) 2012-2013 TJ Holowaychuk
+ * Copyright(c) 2015 Andreas Lubbe
+ * Copyright(c) 2015 Tiancheng "Timothy" Gu
+ * MIT Licensed
+ */
+
+const matchHtmlRegExp = /["'&<>]/;
+
+/**
+ * Escape special characters in the given string of text.
+ *
+ * @param  {string} string The string to escape for inserting into HTML
+ * @return {string}
+ * @public
+ */
+
+export function escapeHtml(string: string) {
+  const str = "" + string;
+  const match = matchHtmlRegExp.exec(str);
+
+  if (!match) {
+    return str;
+  }
+
+  let escape;
+  let html = "";
+  let index = 0;
+  let lastIndex = 0;
+
+  for (index = match.index; index < str.length; index++) {
+    switch (str.charCodeAt(index)) {
+      case 34: // "
+        escape = "&quot;";
+        break;
+      case 38: // &
+        escape = "&amp;";
+        break;
+      case 39: // '
+        escape = "&#39;";
+        break;
+      case 60: // <
+        escape = "&lt;";
+        break;
+      case 62: // >
+        escape = "&gt;";
+        break;
+      default:
+        continue;
+    }
+
+    if (lastIndex !== index) {
+      html += str.substring(lastIndex, index);
+    }
+
+    lastIndex = index + 1;
+    html += escape;
+  }
+
+  return lastIndex !== index ? html + str.substring(lastIndex, index) : html;
+}

--- a/packages/vite/CHANGELOG.md
+++ b/packages/vite/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @web-widget/vite
 
+## 2.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @web-widget/schema@0.1.2
+  - @web-widget/web-router@0.4.2
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/vite",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @web-widget/vue
 
+## 0.4.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @web-widget/schema@0.1.2
+  - @web-widget/html@0.1.2
+  - @web-widget/vite@2.0.2
+  - @web-widget/web-widget@1.0.1
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/vue",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/vue2/CHANGELOG.md
+++ b/packages/vue2/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @web-widget/vue2
 
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @web-widget/schema@0.1.2
+  - @web-widget/vite@2.0.2
+  - @web-widget/web-widget@1.0.1
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/vue2/package.json
+++ b/packages/vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/vue2",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/web-router/CHANGELOG.md
+++ b/packages/web-router/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @web-widget/web-router
 
+## 0.4.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @web-widget/schema@0.1.2
+  - @web-widget/html@0.1.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/web-router/package.json
+++ b/packages/web-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/web-router",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/web-widget/CHANGELOG.md
+++ b/packages/web-widget/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 1.0.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @web-widget/schema@0.1.2
+
 ## 1.0.0
 
 ### Patch Changes

--- a/packages/web-widget/package.json
+++ b/packages/web-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-widget/web-widget",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Web front-end application container",
   "author": "aui",
   "homepage": "https://github.com/web-widget/web-widget#readme",


### PR DESCRIPTION
That the escaped value is only suitable for being interpolated into HTML as the text content of elements in which the tag does not have different escaping mechanisms (it cannot be placed inside `<style>` or `<script>`, for example, as those content bodies are not HTML, but CSS and JavaScript, respectively; these are known as "raw text elements" in the HTML standard).