### PR TITLE
perf: 优化挂件内存释放

### DIFF
--- a/packages/vue2/src/server.ts
+++ b/packages/vue2/src/server.ts
@@ -79,6 +79,9 @@ export const defineVueRender = ({
         ? Readable.toWeb(renderer.renderToStream(app))
         : await renderer.renderToString(app);
 
+    if (app.$destroy && typeof app.$destroy === "function") {
+      app.$destroy();
+    }
     if (state) {
       const json = htmlEscapeJsonString(JSON.stringify(state));
       const script = `<script as="state" type="application/json">${json}</script>`;


### PR DESCRIPTION
一个页面内有多个vue挂件，多个app实例，内存没得到很好的释放，渲染后销毁app实例，减少内存消耗