### PR TITLE
fix: 修复构建链路错误

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -31,6 +31,7 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
+    "@web-widget/web-router": "workspace:*",
     "@types/mime-types": "^2.1.1",
     "@types/node": "^20.4.8",
     "rollup": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,9 +356,6 @@ importers:
       '@web-widget/schema':
         specifier: workspace:*
         version: link:../schema
-      '@web-widget/web-router':
-        specifier: workspace:*
-        version: link:../web-router
       builtin-modules:
         specifier: ^3.3.0
         version: 3.3.0
@@ -393,6 +390,9 @@ importers:
       '@types/node':
         specifier: ^20.4.8
         version: 20.5.7
+      '@web-widget/web-router':
+        specifier: workspace:*
+        version: link:../web-router
       rollup:
         specifier: ^3.3.0
         version: 3.28.0


### PR DESCRIPTION
turborepo 构建依赖 devDependencies 和 dependencies 的分析，@web-widget/vite 依赖的构建产物 @web-widget/web-router，所以需要将 @web-widget/web-router添加到@web-widget/vite的依赖内，turbo才能自动识别构建顺序。