### PR TITLE
feat: 支持在 jsx 中引入 .vue 文件的组件而不产生类型错误

### DIFF
--- a/examples/full/routes/experimental-async-component.route.tsx
+++ b/examples/full/routes/experimental-async-component.route.tsx
@@ -1,5 +1,5 @@
 import { type RouteComponentProps } from "@web-widget/react";
-import type { HelloData } from "./api/hello-world";
+import type { HelloData } from "./api/hello-world.route.ts";
 import BaseLayout from "../components/BaseLayout";
 
 async function fetchData(url: URL) {

--- a/examples/full/routes/index.route.tsx
+++ b/examples/full/routes/index.route.tsx
@@ -11,7 +11,7 @@ export default function Home() {
       <h1 className={styles.title}>Home</h1>
       <p>
         Welcome to @web-widget/web-router. Try to update this message in the
-        ./routes/index.tsx file, and refresh.
+        ./routes/index.route.tsx file, and refresh.
       </p>
     </BaseLayout>
   );

--- a/examples/full/routes/react-and-vue.route.tsx
+++ b/examples/full/routes/react-and-vue.route.tsx
@@ -1,5 +1,5 @@
 import ReactCounter from "../widgets/Counter.widget.tsx";
-import VueCounter from "../widgets/Counter.widget.vue";
+import VueCounter from "../widgets/Counter.widget.vue?as=jsx";
 import VanillaCounter from "../widgets/CounterVanilla.widget.ts";
 import type { Meta } from "@web-widget/react";
 import BaseLayout from "../components/BaseLayout";

--- a/examples/full/routes/react-streaming.route.tsx
+++ b/examples/full/routes/react-streaming.route.tsx
@@ -1,6 +1,6 @@
 import BaseLayout from "../components/BaseLayout";
 import ReactWaitDemo from "../widgets/Wait.widget.jsx";
-import VueWaitDemo from "../widgets/Wait.widget.vue";
+import VueWaitDemo from "../widgets/Wait.widget.vue?as=tsx";
 
 const Loading = (
   <div style={{ background: "#f3f3f3", padding: "20px" }}>Loading..</div>

--- a/packages/react/globals.d.ts
+++ b/packages/react/globals.d.ts
@@ -1,4 +1,4 @@
-import type { ReactNode, ComponentProps } from "react";
+/// <reference types="react" />
 
 interface WebWidgetSuspenseProps {
   fallback?: ReactNode;
@@ -7,20 +7,19 @@ interface WebWidgetSuspenseProps {
   experimental_renderTarget?: "light" | "shadow";
 }
 
-declare global {
-  declare namespace JSX {
-    interface IntrinsicAttributes extends WebWidgetSuspenseProps {
-      key?: Key | null | undefined;
-    }
-  }
-}
-
-interface ReactWidgetComponent extends ComponentProps<any> {
+interface ReactWidgetComponent<T = unknown> extends ComponentProps<any> {
   (
     props: {
       children?: ReactNode;
-    } & WebWidgetSuspenseProps
+    } & WebWidgetSuspenseProps &
+      T
   ): ReactNode;
+}
+
+declare namespace JSX {
+  interface IntrinsicAttributes extends WebWidgetSuspenseProps {
+    key?: Key | null | undefined;
+  }
 }
 
 declare module "*.widget.jsx" {
@@ -28,7 +27,17 @@ declare module "*.widget.jsx" {
   export default reactWidgetComponent;
 }
 
-declare module "*.route.tsx" {
+declare module "*.widget.tsx" {
   const reactWidgetComponent: ReactWidgetComponent;
+  export default reactWidgetComponent;
+}
+
+declare module "*?as=jsx" {
+  const reactWidgetComponent: ReactWidgetComponent<any>;
+  export default reactWidgetComponent;
+}
+
+declare module "*?as=tsx" {
+  const reactWidgetComponent: ReactWidgetComponent<any>;
   export default reactWidgetComponent;
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,9 @@
       "require": "./dist/vite.cjs",
       "default": "./dist/vite.js"
     },
-    "./globals": "./globals.d.ts"
+    "./globals": {
+      "types": "./globals.d.ts"
+    }
   },
   "files": [
     "dist",
@@ -75,7 +77,9 @@
         "require": "./dist/vite.cjs",
         "default": "./dist/vite.js"
       },
-      "./globals": "./globals.d.ts"
+      "./globals": {
+        "types": "./globals.d.ts"
+      }
     }
   }
 }

--- a/packages/vue/src/vite.ts
+++ b/packages/vue/src/vite.ts
@@ -12,7 +12,7 @@ export default function vueWebWidgetPlugin({
   return webWidgetPlugin({
     provide,
     toWebWidgets: {
-      include: [/(\.route|widget).*\.vue(\?.*\.(ts|js))?$/],
+      include: /(\.route|widget).*\.vue(\?as=[^&]*|\?.*\.(ts|js))?$/,
       ...toWebWidgets,
     },
     toComponents: {

--- a/packages/vue2/src/vite.ts
+++ b/packages/vue2/src/vite.ts
@@ -12,7 +12,7 @@ export default function vue2WebWidgetPlugin({
   return webWidgetPlugin({
     provide,
     toWebWidgets: {
-      include: [/(\.route|widget).*\.vue(\?.*\.(ts|js))?$/],
+      include: /(\.route|widget).*\.vue(\?as=[^&]*|\?.*\.(ts|js))?$/,
       ...toWebWidgets,
     },
     toComponents: {


### PR DESCRIPTION
```diff tsx
import ReactCounter from "../widgets/Counter.widget.tsx";
- import VueCounter from "../widgets/Counter.widget.vue";
+ import VueCounter from "../widgets/Counter.widget.vue?as=jsx";
import VanillaCounter from "../widgets/CounterVanilla.widget.ts";
import type { Meta } from "@web-widget/react";
import BaseLayout from "../components/BaseLayout";

export const meta: Meta = {
  title: "Hello, Web Widget",
};

export default function Page() {
  return (
    <BaseLayout>
      <h1>Using react and vue together</h1>

      <h2>React component:</h2>
      <ReactCounter name="Vanilla Counter" start={3} />

      <h2>Vue component:</h2>
      <VueCounter name="Vue3 Counter" start={3} />

      <h2>Vanilla component:</h2>
      <VanillaCounter name="Vanilla Counter" start={3} />
    </BaseLayout>
  );
}
```