### PR TITLE
fix(vite-plugin): sortRoutePaths

### DIFF
--- a/.changeset/five-ravens-greet.md
+++ b/.changeset/five-ravens-greet.md
@@ -1,0 +1,5 @@
+---
+'@web-widget/vite-plugin': patch
+---
+
+Fixed an issue where correct sorting may not occur when files are grouped.

--- a/packages/vite-plugin/src/dev/routing/extract.test.ts
+++ b/packages/vite-plugin/src/dev/routing/extract.test.ts
@@ -46,6 +46,7 @@ test('throws on invalid patterns', () => {
 
 test('sortRoutePaths', () => {
   const routes = [
+    '/(group)/[...all]',
     '/foo/[id]',
     '/foo/[...slug]',
     '/foo/bar',
@@ -70,6 +71,7 @@ test('sortRoutePaths', () => {
     '/foo/bar/[...foo]',
     '/foo/[id]',
     '/foo/[...slug]',
+    '/(group)/[...all]',
   ];
   routes.sort(sortRoutePaths);
   expect(routes).toEqual(sorted);

--- a/packages/vite-plugin/src/dev/routing/extract.ts
+++ b/packages/vite-plugin/src/dev/routing/extract.ts
@@ -1,9 +1,14 @@
+const GROUPS = /\([^)]*\)/g;
 /**
  * Adopted from Fresh
  *
  * https://github.com/denoland/fresh/blob/main/LICENSE
  */
 export function sortRoutePaths(a: string, b: string) {
+  // eslint-disable-next-line no-param-reassign
+  a = a.replace(GROUPS, '');
+  // eslint-disable-next-line no-param-reassign
+  b = b.replace(GROUPS, '');
   let segmentIdx = 0;
   const aLen = a.length;
   const bLen = b.length;


### PR DESCRIPTION
Fixed an issue where correct sorting may not occur when files are grouped.