### PR TITLE
fix(context): TypeError: Failed to construct 'Request'

### DIFF
--- a/.changeset/stale-dolls-care.md
+++ b/.changeset/stale-dolls-care.md
@@ -1,0 +1,5 @@
+---
+'@web-widget/context': patch
+---
+
+Fix TypeError: Failed to construct 'Request': Failed to read the 'headers' property from 'RequestInit': String contains non ISO-8859-1 code point.

--- a/packages/context/src/client.ts
+++ b/packages/context/src/client.ts
@@ -16,12 +16,12 @@ export function createSafeSerializableContext(
     request: new Request(location.href, {
       method: 'GET', // TODO: Use the actual method.
       headers: {
-        'user-agent': navigator.userAgent,
-        cookie: document.cookie,
+        'user-agent': encodeURIComponent(navigator.userAgent),
+        cookie: encodeURIComponent(document.cookie),
         host: location.host,
         origin: location.origin,
-        referer: document.referrer,
-        'accept-language': navigator.language,
+        referer: encodeURIComponent(document.referrer),
+        'accept-language': encodeURIComponent(navigator.language),
       },
     }),
     state: Object.create(null),


### PR DESCRIPTION
Fix TypeError: Failed to construct 'Request': Failed to read the 'headers' property from 'RequestInit': String contains non ISO-8859-1 code point.