### PR TITLE
fix(web-router): handleEvent

### DIFF
--- a/.changeset/angry-terms-wave.md
+++ b/.changeset/angry-terms-wave.md
@@ -1,0 +1,5 @@
+---
+'@web-widget/web-router': patch
+---
+
+Fix `handleEvent`.

--- a/packages/web-router/src/application.ts
+++ b/packages/web-router/src/application.ts
@@ -202,8 +202,12 @@ class Application<
     })();
   }
 
+  /**
+   * Implements the (ancient) event listener object interface to allow passing to fetch event directly,
+   * e.g. `self.addEventListener('fetch', webRouter)`.
+   */
   handleEvent = (event: FetchEventLike) => {
-    return this.handler(event.request, undefined, event);
+    event.respondWith(this.handler(event.request, undefined, event));
   };
 
   /**

--- a/packages/web-router/src/types.ts
+++ b/packages/web-router/src/types.ts
@@ -54,7 +54,7 @@ export type ErrorHandler<E extends Env = any> = (
 export abstract class FetchEventLike {
   abstract readonly request: Request;
   abstract respondWith(promise: Response | Promise<Response>): void;
-  abstract passThroughOnException(): void;
+  abstract passThroughOnException?(): void;
   abstract waitUntil(promise: Promise<void>): void;
 }
 


### PR DESCRIPTION
Implements the (ancient) event listener object interface to allow passing to fetch event directly.

```ts
self.addEventListener('fetch', webRouter);
```