### PR TITLE
feat(web-widget): record performance

### DIFF
--- a/.changeset/friendly-ligers-shout.md
+++ b/.changeset/friendly-ligers-shout.md
@@ -1,0 +1,5 @@
+---
+'@web-widget/web-widget': minor
+---
+
+Support Web performance API to record performance.

--- a/packages/web-widget/src/element.ts
+++ b/packages/web-widget/src/element.ts
@@ -569,12 +569,44 @@ export class HTMLWebWidgetElement extends HTMLElement {
       this.removeAttribute('recovering');
     }
 
+    const name = this.localName;
+    const markNameSpace = `${name}:statusChange`;
+    const detail = {
+      name: this.#name,
+      import: this.import,
+    };
+    performance.mark(`${markNameSpace}:${value}`, {
+      detail,
+    });
+
+    switch (value) {
+      case status.LOADED:
+        performance.measure(`${name}:load`, {
+          start: `${markNameSpace}:${status.LOADING}`,
+          end: `${markNameSpace}:${status.LOADED}`,
+          detail,
+        });
+        break;
+      case status.MOUNTED:
+        performance.measure(`${name}:mount`, {
+          start: `${markNameSpace}:${status.MOUNTING}`,
+          end: `${markNameSpace}:${status.MOUNTED}`,
+          detail,
+        });
+        break;
+    }
+
     this.dispatchEvent(new Event('statuschange'));
   }
 
+  get #name() {
+    return (
+      this.id || this.getAttribute('name') || this.import || this.localName
+    );
+  }
+
   #throwGlobalError(error: Error) {
-    const moduleName =
-      this.id || this.getAttribute('name') || this.import || this.localName;
+    const moduleName = this.#name;
     const prefix = `Web Widget module (${moduleName})`;
     if (typeof error !== 'object') {
       error = new Error(error, {

--- a/packages/web-widget/src/element.ts
+++ b/packages/web-widget/src/element.ts
@@ -24,6 +24,11 @@ const innerHTMLDescriptor = Object.getOwnPropertyDescriptor(
 )!;
 const innerHTMLSetter = innerHTMLDescriptor.set!;
 
+export type PerformanceMarkDetail = {
+  name: string;
+  import: string;
+};
+
 export const INNER_HTML_PLACEHOLDER = `<!--web-widget:placeholder-->`;
 
 /**
@@ -571,10 +576,11 @@ export class HTMLWebWidgetElement extends HTMLElement {
 
     const name = this.localName;
     const markNameSpace = `${name}:statusChange`;
-    const detail = {
+    const detail: PerformanceMarkDetail = {
       name: this.#name,
       import: this.import,
     };
+
     performance.mark(`${markNameSpace}:${value}`, {
       detail,
     });


### PR DESCRIPTION
```js
const observer = new PerformanceObserver((list) => {
  list.getEntries().forEach((entry) => {
    if (entry.entryType === 'measure') {
      console.log(`Measure: ${entry.name}`);
      console.log(`Start Time: ${entry.startTime}`);
      console.log(`Duration: ${entry.duration}`);
      console.log(`Detail:`, entry.detail);
    }
  });
});

observer.observe({ entryTypes: ['measure'] });
```