### PR TITLE
feat: support `serverOnly` option for `cacheProvider`

### DIFF
--- a/.changeset/light-needles-grin.md
+++ b/.changeset/light-needles-grin.md
@@ -1,0 +1,8 @@
+---
+'@web-widget/lifecycle-cache': minor
+'@web-widget/web-widget': minor
+'@web-widget/vue2': minor
+'@web-widget/vue': minor
+---
+
+Support `serverOnly` option for `cacheProvider`.

--- a/packages/lifecycle-cache/src/provider.test.ts
+++ b/packages/lifecycle-cache/src/provider.test.ts
@@ -1,21 +1,20 @@
-import { cacheProvider, syncCacheProvider } from './provider';
+import {
+  cacheProvider,
+  callSyncCacheProvider,
+  syncCacheProvider,
+} from './provider';
 import { LifecycleCache } from './cache';
 
 let id = 0;
 const createCacheKey = () => `cacheKey:${id++}`;
+function composeCacheKey(cacheKey: string, args?: any[]): string {
+  cacheKey = `^${cacheKey}`;
+  return args?.length ? `${cacheKey}#${JSON.stringify(args)}` : cacheKey;
+}
 
 const mockCache = new LifecycleCache<any>({});
-async function suspense<T>(handler: () => T) {
-  try {
-    return await handler();
-  } catch (error) {
-    if (error instanceof Promise) {
-      await error;
-      return suspense(handler);
-    } else {
-      throw error;
-    }
-  }
+function getMockCache(cacheKey: string, args?: any[]) {
+  return mockCache.get(composeCacheKey(cacheKey, args));
 }
 
 describe('cacheProvider', () => {
@@ -28,7 +27,7 @@ describe('cacheProvider', () => {
       cacheKey,
       async () => 'newValue',
       undefined,
-      mockCache
+      { cache: mockCache }
     );
     expect(result).toBe(cachedValue);
   });
@@ -40,77 +39,78 @@ describe('cacheProvider', () => {
       cacheKey,
       async () => 'newValue',
       undefined,
-      mockCache
+      { cache: mockCache }
     );
     expect(result).toBe('newValue');
-    expect(mockCache.get(cacheKey)).toBe('newValue');
+    expect(getMockCache(cacheKey)).toBe('newValue');
   });
 
   test('the parameters should be passed to the handler', async () => {
     const cacheKey = createCacheKey();
-    const args = ['arg1', 'arg2'];
+    const args1 = ['arg1', 'arg2'];
+    const args2 = ['arg3', 'arg4'];
 
-    const result = await cacheProvider(
-      cacheKey,
-      async (...handlerArgs: string[]) => handlerArgs.join(' '),
-      args,
-      mockCache
-    );
-    expect(result).toBe(args.join(' '));
-    expect(mockCache.get(cacheKey)).toBe(args.join(' '));
+    const fn = async (args: string[]) =>
+      cacheProvider(
+        cacheKey,
+        async (...handlerArgs: string[]) => handlerArgs.join(' '),
+        args,
+        { cache: mockCache }
+      );
+
+    const result1 = await fn(args1);
+    expect(result1).toBe(args1.join(' '));
+    expect(getMockCache(cacheKey, args1)).toBe(args1.join(' '));
+
+    const result2 = await fn(args2);
+    expect(result2).toBe(args2.join(' '));
+    expect(getMockCache(cacheKey, args2)).toBe(args2.join(' '));
   });
 
   test('should throw an error if handler is not provided', async () => {
     const cacheKey = createCacheKey();
 
     await expect(
-      cacheProvider(cacheKey, undefined as any, undefined, mockCache)
+      cacheProvider(cacheKey, undefined as any, undefined, { cache: mockCache })
     ).rejects.toThrow('Handler is required.');
   });
 
   test('should throw an error if handler returns null', async () => {
     const cacheKey = createCacheKey();
     await expect(
-      cacheProvider(cacheKey, (async () => null) as any, undefined, mockCache)
+      cacheProvider(cacheKey, (async () => null) as any, undefined, {
+        cache: mockCache,
+      })
     ).rejects.toThrow('The cached value cannot be null or undefined.');
   });
 
   test('should throw an error if handler returns undefined', async () => {
     const cacheKey = createCacheKey();
     await expect(
-      cacheProvider(
-        cacheKey,
-        (async () => undefined) as any,
-        undefined,
-        mockCache
-      )
+      cacheProvider(cacheKey, (async () => undefined) as any, undefined, {
+        cache: mockCache,
+      })
     ).rejects.toThrow('The cached value cannot be null or undefined.');
   });
 
   test('should be cached if the handler returns empty string', async () => {
     const cacheKey = createCacheKey();
 
-    const result = await cacheProvider(
-      cacheKey,
-      () => '',
-      undefined,
-      mockCache
-    );
+    const result = await cacheProvider(cacheKey, () => '', undefined, {
+      cache: mockCache,
+    });
     expect(result).toBe('');
-    expect(mockCache.get(cacheKey)).toBe('');
+    expect(getMockCache(cacheKey)).toBe('');
   });
 
   test('should be cached if the handler returns 0', async () => {
     const cacheKey = createCacheKey();
 
-    const result = await cacheProvider(
-      cacheKey,
-      async () => 0,
-      undefined,
-      mockCache
-    );
+    const result = await cacheProvider(cacheKey, async () => 0, undefined, {
+      cache: mockCache,
+    });
     expect(result).toBe(0);
-    expect(mockCache.get(cacheKey)).toBe(0);
+    expect(getMockCache(cacheKey)).toBe(0);
   });
 
   test('should handle sync handler', async () => {
@@ -120,10 +120,10 @@ describe('cacheProvider', () => {
       cacheKey,
       () => Promise.resolve('syncValue'),
       undefined,
-      mockCache
+      { cache: mockCache }
     );
     expect(result).toBe('syncValue');
-    expect(mockCache.get(cacheKey)).toBe('syncValue');
+    expect(getMockCache(cacheKey)).toBe('syncValue');
   });
 });
 
@@ -133,8 +133,10 @@ describe('syncCacheProvider', () => {
     const cachedValue = 'cachedValue';
     mockCache.set(cacheKey, cachedValue);
 
-    const result = await suspense(() =>
-      syncCacheProvider(cacheKey, async () => 'newValue', undefined, mockCache)
+    const result = await callSyncCacheProvider(() =>
+      syncCacheProvider(cacheKey, async () => 'newValue', undefined, {
+        cache: mockCache,
+      })
     );
     expect(result).toBe(cachedValue);
   });
@@ -142,35 +144,45 @@ describe('syncCacheProvider', () => {
   test('should call handler and cache the result if not cached', async () => {
     const cacheKey = createCacheKey();
 
-    const result = await suspense(() =>
-      syncCacheProvider(cacheKey, async () => 'newValue', undefined, mockCache)
+    const result = await callSyncCacheProvider(() =>
+      syncCacheProvider(cacheKey, async () => 'newValue', undefined, {
+        cache: mockCache,
+      })
     );
     expect(result).toBe('newValue');
-    expect(mockCache.get(cacheKey)).toBe('newValue');
+    expect(getMockCache(cacheKey)).toBe('newValue');
   });
 
   test('the parameters should be passed to the handler', async () => {
     const cacheKey = createCacheKey();
-    const args = ['arg1', 'arg2'];
+    const args1 = ['arg1', 'arg2'];
+    const args2 = ['arg3', 'arg4'];
 
-    const result = await suspense(() =>
+    const fn = async (args: string[]) =>
       syncCacheProvider(
         cacheKey,
         async (...handlerArgs: string[]) => handlerArgs.join(' '),
         args,
-        mockCache
-      )
-    );
-    expect(result).toBe(args.join(' '));
-    expect(mockCache.get(cacheKey)).toBe(args.join(' '));
+        { cache: mockCache }
+      );
+
+    const result1 = await callSyncCacheProvider(() => fn(args1));
+    expect(result1).toBe(args1.join(' '));
+    expect(getMockCache(cacheKey, args1)).toBe(args1.join(' '));
+
+    const result2 = await callSyncCacheProvider(() => fn(args2));
+    expect(result2).toBe(args2.join(' '));
+    expect(getMockCache(cacheKey, args2)).toBe(args2.join(' '));
   });
 
   test('should throw an error if handler is not provided', async () => {
     const cacheKey = createCacheKey();
 
     await expect(
-      suspense(() =>
-        syncCacheProvider(cacheKey, undefined as any, undefined, mockCache)
+      callSyncCacheProvider(() =>
+        syncCacheProvider(cacheKey, undefined as any, undefined, {
+          cache: mockCache,
+        })
       )
     ).rejects.toThrow('Handler is required.');
   });
@@ -178,13 +190,10 @@ describe('syncCacheProvider', () => {
   test('should throw an error if handler returns null', async () => {
     const cacheKey = createCacheKey();
     await expect(
-      suspense(() =>
-        syncCacheProvider(
-          cacheKey,
-          (async () => null) as any,
-          undefined,
-          mockCache
-        )
+      callSyncCacheProvider(() =>
+        syncCacheProvider(cacheKey, (async () => null) as any, undefined, {
+          cache: mockCache,
+        })
       )
     ).rejects.toThrow('The cached value cannot be null or undefined.');
   });
@@ -192,13 +201,10 @@ describe('syncCacheProvider', () => {
   test('should throw an error if handler returns undefined', async () => {
     const cacheKey = createCacheKey();
     await expect(
-      suspense(() =>
-        syncCacheProvider(
-          cacheKey,
-          (async () => undefined) as any,
-          undefined,
-          mockCache
-        )
+      callSyncCacheProvider(() =>
+        syncCacheProvider(cacheKey, (async () => undefined) as any, undefined, {
+          cache: mockCache,
+        })
       )
     ).rejects.toThrow('The cached value cannot be null or undefined.');
   });
@@ -206,35 +212,37 @@ describe('syncCacheProvider', () => {
   test('should be cached if the handler returns empty string', async () => {
     const cacheKey = createCacheKey();
 
-    const result = await suspense(() =>
-      syncCacheProvider(cacheKey, () => '', undefined, mockCache)
+    const result = await callSyncCacheProvider(() =>
+      syncCacheProvider(cacheKey, () => '', undefined, { cache: mockCache })
     );
     expect(result).toBe('');
-    expect(mockCache.get(cacheKey)).toBe('');
+    expect(getMockCache(cacheKey)).toBe('');
   });
 
   test('should be cached if the handler returns 0', async () => {
     const cacheKey = createCacheKey();
 
-    const result = await suspense(() =>
-      syncCacheProvider(cacheKey, async () => 0, undefined, mockCache)
+    const result = await callSyncCacheProvider(() =>
+      syncCacheProvider(cacheKey, async () => 0, undefined, {
+        cache: mockCache,
+      })
     );
     expect(result).toBe(0);
-    expect(mockCache.get(cacheKey)).toBe(0);
+    expect(getMockCache(cacheKey)).toBe(0);
   });
 
   test('should handle sync handler', async () => {
     const cacheKey = createCacheKey();
 
-    const result = await suspense(() =>
+    const result = await callSyncCacheProvider(() =>
       syncCacheProvider(
         cacheKey,
         () => Promise.resolve('syncValue'),
         undefined,
-        mockCache
+        { cache: mockCache }
       )
     );
     expect(result).toBe('syncValue');
-    expect(mockCache.get(cacheKey)).toBe('syncValue');
+    expect(getMockCache(cacheKey)).toBe('syncValue');
   });
 });

--- a/packages/lifecycle-cache/src/provider.test.ts
+++ b/packages/lifecycle-cache/src/provider.test.ts
@@ -21,7 +21,7 @@ describe('cacheProvider', () => {
   test('should return cached value if available', async () => {
     const cacheKey = createCacheKey();
     const cachedValue = 'cachedValue';
-    mockCache.set(cacheKey, cachedValue);
+    mockCache.set(composeCacheKey(cacheKey, undefined), cachedValue);
 
     const result = await cacheProvider(
       cacheKey,
@@ -131,7 +131,7 @@ describe('syncCacheProvider', () => {
   test('should return cached value if available', async () => {
     const cacheKey = createCacheKey();
     const cachedValue = 'cachedValue';
-    mockCache.set(cacheKey, cachedValue);
+    mockCache.set(composeCacheKey(cacheKey, undefined), cachedValue);
 
     const result = await callSyncCacheProvider(() =>
       syncCacheProvider(cacheKey, async () => 'newValue', undefined, {

--- a/packages/vue/src/client.ts
+++ b/packages/vue/src/client.ts
@@ -3,6 +3,7 @@ import { defineRender, getComponentDescriptor } from '@web-widget/helpers';
 import type { App } from 'vue';
 import { Suspense, createApp, createSSRApp, h } from 'vue';
 import type { CreateVueRenderOptions } from './types';
+import installErrorHandler from './error-handler';
 
 export * from '@web-widget/helpers';
 export { useWidgetAsyncState as useWidgetState } from '@web-widget/helpers/state';
@@ -35,6 +36,8 @@ export const createVueRender = ({
         } else {
           app = createApp(WidgetSuspense, props as any);
         }
+
+        installErrorHandler(app);
         await onCreatedApp(app, context, component, props);
 
         app.mount(container);

--- a/packages/vue/src/error-handler.ts
+++ b/packages/vue/src/error-handler.ts
@@ -1,0 +1,16 @@
+import type { App } from 'vue';
+import { cacheProviderIsLoading } from '@web-widget/helpers/cache';
+
+export default function installErrorHandler(app: App<Element>) {
+  /**
+   * The thrown promise is not necessarily a real error,
+   * it will be handled by the web widget container.
+   * @link ../lifecycle-cache/src/provider.ts#cacheProviderIsLoading
+   */
+  app.config.errorHandler = (err, instance, info) => {
+    if (cacheProviderIsLoading(err)) {
+      return;
+    }
+    throw err;
+  };
+}

--- a/packages/vue/src/server.ts
+++ b/packages/vue/src/server.ts
@@ -2,6 +2,7 @@ import { defineRender, getComponentDescriptor } from '@web-widget/helpers';
 import { createSSRApp, h, Suspense } from 'vue';
 import { renderToWebStream, type SSRContext } from 'vue/server-renderer';
 import type { CreateVueRenderOptions } from './types';
+import installErrorHandler from './error-handler';
 
 declare module '@web-widget/schema' {
   interface WidgetRenderOptions {
@@ -37,18 +38,7 @@ export const createVueRender = ({
         h(Suspense, null, [h(component, props)]);
       const app = createSSRApp(WidgetSuspense, props as any);
 
-      /**
-       * The thrown promise is not necessarily a real error,
-       * it will be handled by the web widget container.
-       * @see ../../web-widget/src/server.ts#suspense
-       */
-      app.config.errorHandler = (err, instance, info) => {
-        if (err instanceof Promise) {
-          return;
-        }
-        throw err;
-      };
-
+      installErrorHandler(app);
       await onCreatedApp(app, context, component, props);
       return renderToWebStream(app, ssrContext);
     }

--- a/packages/vue2/src/components.ts
+++ b/packages/vue2/src/components.ts
@@ -8,6 +8,18 @@ import { DefaultProps } from 'vue/types/options';
 
 Vue.config.ignoredElements = ['web-widget'];
 
+/**
+ * The thrown promise is not necessarily a real error,
+ * it will be handled by the web widget container.
+ * @link ../lifecycle-cache/src/provider.ts#cacheProviderIsLoading
+ */
+Vue.config.warnHandler = (msg, vm, trace) => {
+  if (msg === `Error in setup: "[object Promise]"`) {
+    return;
+  }
+  console.error('[Vue warn]: '.concat(msg).concat(trace));
+};
+
 type WebWidgetRenderer = InstanceType<typeof WebWidgetRenderer>;
 
 export interface DefineWebWidgetOptions {

--- a/packages/vue2/src/server.ts
+++ b/packages/vue2/src/server.ts
@@ -11,18 +11,6 @@ export * from '@web-widget/helpers';
 export { useWidgetSyncState as useWidgetState } from '@web-widget/helpers/state';
 export * from './components';
 
-/**
- * The thrown promise is not necessarily a real error,
- * it will be handled by the web widget container.
- * @see ../../web-widget/src/server.ts#suspense
- */
-Vue.config.warnHandler = (msg, vm, trace) => {
-  if (msg === `Error in setup: "[object Promise]"`) {
-    return;
-  }
-  console.error('[Vue warn]: '.concat(msg).concat(trace));
-};
-
 // const __FEATURE_STREAM__ = false;
 
 // function appendStringToReadableStream(

--- a/packages/web-widget/src/element.ts
+++ b/packages/web-widget/src/element.ts
@@ -3,7 +3,10 @@ import type {
   ClientWidgetRenderContext,
   Meta,
 } from '@web-widget/helpers';
-import { mountLifecycleCacheLayer } from '@web-widget/lifecycle-cache/client';
+import {
+  mountLifecycleCacheLayer,
+  callSyncCacheProvider,
+} from '@web-widget/lifecycle-cache/client';
 import { WebWidgetUpdateEvent } from './event';
 import { LifecycleController } from './modules/controller';
 import { status } from './modules/status';
@@ -436,7 +439,7 @@ export class HTMLWebWidgetElement extends HTMLElement {
    * Trigger the mounting of the module.
    */
   async mount(): Promise<void> {
-    await this.#trigger('mount');
+    await callSyncCacheProvider(() => this.#trigger('mount'));
   }
 
   /**


### PR DESCRIPTION
## examples

```ts
const data = cacheProvider(cacheKey, fetchData, undefined, {
  serverOnly: isSpider
});
```

The server no longer serializes the lifecycle cache, so the client will initiate the request.

> Note: If the request data on the server and client are inconsistent, a hydration error will occur.