### PR TITLE
fix: prevent race condition in autoMount execution

### DIFF
--- a/.changeset/fix-race-condition.md
+++ b/.changeset/fix-race-condition.md
@@ -1,0 +1,5 @@
+---
+'@web-widget/web-widget': patch
+---
+
+Fix race condition in autoMount execution that caused "Cannot perform 'load' from 'loading' to 'loading'" errors when multiple triggers occurred simultaneously. Added Promise-based deduplication and comprehensive test coverage.


### PR DESCRIPTION
- Add Promise-based deduplication to prevent multiple autoMount calls
- Only allow autoMount from INITIAL or LOAD_ERROR states
- Maintain microtask delay for proper async behavior
- Add comprehensive test coverage for race conditions
- Improve code comments for better maintainability

Fixes the "Cannot perform 'load' from 'loading' to 'loading'" error that occurred when multiple triggers (set loader, attributeChangedCallback) called autoMount simultaneously before status changed from INITIAL.