### PR TITLE
fix(web-router): restore async context in Application error path

### DIFF
--- a/.changeset/fix-716-error-handler-context.md
+++ b/.changeset/fix-716-error-handler-context.md
@@ -1,0 +1,7 @@
+---
+'@web-widget/web-router': patch
+---
+
+Re-enter request async context (`callContext`) when handling errors in `Application.handler`, so `onError` and custom fallback rendering can use `context()` and other ALS-backed APIs after a thrown error.
+
+Fixes [#716](https://github.com/web-widget/web-widget/issues/716).

--- a/packages/web-router/src/application.test.ts
+++ b/packages/web-router/src/application.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { callContext, context } from '@web-widget/context/server';
 import { Application } from './application';
 import type { MiddlewareHandler } from './types';
 import { getPath } from './url';
@@ -793,6 +794,33 @@ describe('error handle', () => {
       expect(res.status).toBe(500);
       expect(await res.text()).toBe('Custom Error: This is Middleware Error');
       expect(res.headers.get('x-debug')).toBe('This is Middleware Error');
+    });
+  });
+
+  describe('onError restores async context (web-widget#716)', () => {
+    const app = new Application();
+
+    app.use('*', callContext);
+
+    app.use('*', async (c, next) => {
+      c.state.marker = 'from-middleware';
+      return next();
+    });
+
+    app.get('/throws', () => {
+      throw new Error('route boom');
+    });
+
+    app.onError(async () => {
+      const ctx = context();
+      const marker = (ctx.state as { marker?: string }).marker ?? 'missing';
+      return text(`marker=${marker}`, { status: 500 });
+    });
+
+    test('context() works in onError after route throw', async () => {
+      const res = await app.dispatch('https://example.com/throws');
+      expect(res.status).toBe(500);
+      expect(await res.text()).toBe('marker=from-middleware');
     });
   });
 });

--- a/packages/web-router/src/application.ts
+++ b/packages/web-router/src/application.ts
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Application domain object - HTTP request/response lifecycle management
  */
+import { callContext } from '@web-widget/context/server';
 import { compose } from '@web-widget/helpers';
 import { normalizeForwardedRequest } from '@web-widget/helpers/proxy';
 import { createHttpError } from '@web-widget/helpers/error';
@@ -231,9 +232,10 @@ class Application<
         return res;
       } catch (error) {
         this.fixErrorStack(error as Error);
-        return this.#errorHandler(
-          await this.#normalizeHTTPException(error),
-          context
+        // Re-enter AsyncLocalStorage / unctx scope so onError and fallbacks can use
+        // context() and other ALS-backed APIs (see web-widget#716).
+        return callContext(context, async () =>
+          this.#errorHandler(await this.#normalizeHTTPException(error), context)
         );
       }
     })();


### PR DESCRIPTION
Re-enter callContext in handler catch so onError and route fallbacks can use context() after thrown errors. Fixes #716.