### PR TITLE
fix(vite-plugin): include css for ?as= widget dynamic imports

### DIFF
--- a/.changeset/funny-cups-share.md
+++ b/.changeset/funny-cups-share.md
@@ -1,0 +1,5 @@
+---
+'@web-widget/vite-plugin': patch
+---
+
+Fix SSR CSS collection for widget modules imported with `?as=...` (for example `?as=jsx`) so dynamic widget styles are included consistently with non-query imports.

--- a/packages/vite-plugin/src/manifest-links.test.ts
+++ b/packages/vite-plugin/src/manifest-links.test.ts
@@ -170,6 +170,36 @@ describe('getLinks', () => {
     expect(links.some((l) => l.href?.includes('w-inner.js'))).toBe(false);
   });
 
+  test('dynamicImport with ?as= query still matches predicate written for source path', () => {
+    const m = {
+      'routes/page@route.tsx': {
+        file: 'assets/page.js',
+        src: 'routes/page@route.tsx',
+        imports: [],
+        dynamicImports: ['routes/Demo@widget.vue?as=jsx'],
+        css: [],
+      },
+      'routes/Demo@widget.vue?as=jsx': {
+        file: 'assets/demo-widget.js',
+        src: 'routes/Demo@widget.vue?as=jsx',
+        imports: [],
+        dynamicImports: [],
+        css: ['assets/demo-widget.css'],
+      },
+    } as unknown as Manifest;
+
+    // Common user predicate: match widget source path without query parameters.
+    const predicate = (key: string) => /[.@]widget\.[^?]*$/.test(key);
+    const links = getLinks(
+      m,
+      'routes/page@route.tsx',
+      base,
+      new Set(),
+      predicate
+    );
+    expect(links.map((l) => l.href)).toContain(`${base}assets/demo-widget.css`);
+  });
+
   test('static import chain propagates dynamicImportPredicate: intermediary chunk’s dynamicImport(widget) still emits CSS', () => {
     const m = {
       'routes/page@route.tsx': {

--- a/packages/vite-plugin/src/manifest-links.ts
+++ b/packages/vite-plugin/src/manifest-links.ts
@@ -11,6 +11,7 @@ const RESOLVE_URL_REG = /^(?:\w+:)?\//;
 const rebase = (src: string, base: string) => {
   return RESOLVE_URL_REG.test(src) ? src : base + src;
 };
+const stripAsQuery = (src: string) => src.replace(/\?as=.*/, '');
 
 function getLink(fileName: string, base: string): LinkDescriptor | null {
   const ext = path.extname(fileName);
@@ -104,8 +105,17 @@ function getLinksInternal(
     });
   }
 
+  const canFollowDynamicImport = (dep: string) => {
+    if (!dynamicImportPredicate) {
+      return false;
+    }
+    return (
+      dynamicImportPredicate(dep) || dynamicImportPredicate(stripAsQuery(dep))
+    );
+  };
+
   if (dynamicImportPredicate && Array.isArray(item.dynamicImports)) {
-    item.dynamicImports.filter(dynamicImportPredicate).forEach((dep) => {
+    item.dynamicImports.filter(canFollowDynamicImport).forEach((dep) => {
       links.push(
         ...getLinksInternal(
           manifest,


### PR DESCRIPTION
Handle dynamic import manifest keys with `?as=` query when applying the dynamic import predicate so SSR CSS links are preserved for `@widget` modules imported as JSX. Add a regression test and changeset entry.