### PR TITLE
feat: rewrite api

### DIFF
--- a/.changeset/feat-runtime-rewrite.md
+++ b/.changeset/feat-runtime-rewrite.md
@@ -1,0 +1,11 @@
+---
+'@web-widget/web-router': minor
+'@web-widget/schema': minor
+'@web-widget/helpers': patch
+---
+
+Add runtime internal URL rewrite: `context.rewrite(destination)` re-matches and runs the target route handler chain while keeping `context.request` (the browser URL) unchanged. Supports same-origin destinations, query merge, skipping already-run global (`*`) middleware, nested depth limits, and loop detection.
+
+- **@web-widget/schema**: optional `rewrite()` on `FetchContext`.
+- **@web-widget/web-router**: `rewrite` implementation, matched-stack runner, `getPathFromResolvedUrl`, tests, and RFC `rfcs/rewrite.zh.md`.
+- **@web-widget/helpers**: `compose` awaits middleware return values so async handlers and `rewrite()` rejections propagate to `onError` reliably.

--- a/packages/helpers/src/module/compose.ts
+++ b/packages/helpers/src/module/compose.ts
@@ -53,7 +53,7 @@ export function compose<
       }
 
       if (handler) {
-        return (handler as Function)(context, () => {
+        return await (handler as Function)(context, () => {
           return dispatch(i + 1);
         });
       } else {

--- a/packages/schema/types/http.d.ts
+++ b/packages/schema/types/http.d.ts
@@ -102,4 +102,11 @@ export interface FetchContext<Params = Record<string, string>> extends Omit<
    * @deprecated This property is deprecated and will be removed in a future version.
    */
   readonly pathname: string;
+
+  /**
+   * Internally rewrite to `destination` (relative paths resolve against `request.url`).
+   * Returns the target path handler chain's `Response`; usage mirrors `next()`.
+   * The browser URL (`request`) is unchanged.
+   */
+  rewrite?(destination: string | URL): Response | Promise<Response>;
 }

--- a/packages/web-router/src/application.test.ts
+++ b/packages/web-router/src/application.test.ts
@@ -2,7 +2,7 @@
 import { callContext, context } from '@web-widget/context/server';
 import { Application } from './application';
 import type { MiddlewareHandler } from './types';
-import { getPath } from './url';
+import { getPathForRequest } from './url';
 
 // https://stackoverflow.com/a/65666402
 function throwExpression(errorMessage: string): never {
@@ -238,7 +238,7 @@ describe('strict parameter', () => {
   describe('strict is false with `getPath` option', () => {
     const app = new Application({
       strict: false,
-      getPath: getPath,
+      getPath: getPathForRequest,
     });
 
     app.get('/hello', (c) => {
@@ -1418,8 +1418,6 @@ declare module './context' {
 // });
 
 describe('normalizeHTTPException', () => {
-  const app = new Application();
-
   // Test basic error handling
   test('should handle basic errors', async () => {
     const testApp = new Application();
@@ -1720,5 +1718,221 @@ describe('normalizeHTTPException', () => {
     await testApp.dispatch('/test-error');
 
     expect(capturedError.cause).toBe(objectError);
+  });
+});
+
+describe('rewrite', () => {
+  describe('response', () => {
+    test('returns the target route handler result', async () => {
+      const app = new Application();
+
+      app.get('/gateway', (ctx) => ctx.rewrite!('/target'));
+      app.get('/target', () => text('from-target'));
+
+      const res = await app.dispatch('http://localhost/gateway');
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('from-target');
+    });
+
+    test('allows the caller to adjust the rewritten response', async () => {
+      const app = new Application();
+
+      app.use('*', async (ctx, next) => {
+        const url = new URL(ctx.request.url);
+        if (!url.pathname.startsWith('/v1/')) {
+          return next();
+        }
+        const res = await ctx.rewrite!(
+          new URL(url.pathname.replace(/^\/v1/, '/internal'), url)
+        );
+        res.headers.set('x-routed-by', 'v1-gateway');
+        return res;
+      });
+
+      app.get('/internal/:id', () => text('ok'));
+
+      const res = await app.dispatch('http://localhost/v1/products');
+      expect(res.headers.get('x-routed-by')).toBe('v1-gateway');
+    });
+  });
+
+  describe('external request URL', () => {
+    test('keeps ctx.request.url on the original client URL', async () => {
+      const app = new Application();
+
+      app.get('/gateway', (ctx) => ctx.rewrite!('/target'));
+      app.get('/target', (ctx) => text(new URL(ctx.request.url).pathname));
+
+      const res = await app.dispatch('http://localhost/gateway?foo=1');
+      expect(await res.text()).toBe('/gateway');
+    });
+  });
+
+  describe('query string', () => {
+    test('preserves search when destination omits query', async () => {
+      const app = new Application();
+
+      app.get('/gateway', (ctx) => ctx.rewrite!('/target'));
+      app.get('/target', (ctx) => text(new URL(ctx.request.url).search));
+
+      const res = await app.dispatch('http://localhost/gateway?foo=1');
+      expect(await res.text()).toBe('?foo=1');
+    });
+  });
+
+  describe('params and pathname', () => {
+    test('binds params from the rewritten route pattern', async () => {
+      const app = new Application();
+
+      app.use('*', async (ctx, next) => {
+        const url = new URL(ctx.request.url);
+        if (!url.pathname.startsWith('/v1/')) {
+          return next();
+        }
+        return ctx.rewrite!(
+          new URL(url.pathname.replace(/^\/v1/, '/internal'), url)
+        );
+      });
+
+      app.get('/internal/:id', (ctx) => text(`id:${ctx.params.id}`));
+
+      const res = await app.dispatch('http://localhost/v1/products');
+      expect(await res.text()).toBe('id:products');
+    });
+
+    test('replaces params when external and internal patterns differ', async () => {
+      const app = new Application();
+      let paramsBeforeRewrite: Record<string, string> = {};
+
+      app.get('/edge/:version/:id', (ctx) => {
+        paramsBeforeRewrite = { ...ctx.params };
+        return ctx.rewrite!(`/core/${ctx.params.id}`);
+      });
+
+      app.get('/core/:itemId', (ctx) =>
+        text(
+          JSON.stringify({
+            itemId: ctx.params.itemId,
+            version: (ctx.params as Record<string, string>).version,
+            pathname: ctx.pathname,
+            urlPath: new URL(ctx.request.url).pathname,
+          })
+        )
+      );
+
+      const res = await app.dispatch('http://localhost/edge/v2/item-9');
+      const body = JSON.parse(await res.text()) as {
+        itemId: string;
+        version?: string;
+        pathname: string;
+        urlPath: string;
+      };
+
+      expect(paramsBeforeRewrite).toEqual({ version: 'v2', id: 'item-9' });
+      expect(body.itemId).toBe('item-9');
+      expect(body.version).toBeUndefined();
+      expect(body.pathname).toBe('/core/:itemId');
+      expect(body.urlPath).toBe('/edge/v2/item-9');
+    });
+  });
+
+  describe('middleware stack', () => {
+    test('does not re-run global (*) middleware already executed', async () => {
+      const app = new Application();
+      let globalRuns = 0;
+
+      app.use('*', async (ctx, next) => {
+        globalRuns += 1;
+        if (ctx.request.url.includes('/v1/')) {
+          return ctx.rewrite!('/internal');
+        }
+        return next();
+      });
+
+      app.get('/internal', () => text('ok'));
+
+      await app.dispatch('http://localhost/v1/x');
+      expect(globalRuns).toBe(1);
+    });
+
+    test('still runs route-scoped middleware registered for the target path', async () => {
+      const app = new Application();
+      let scopedRuns = 0;
+
+      app.use('*', async (ctx, next) => {
+        if (ctx.request.url.includes('/gateway')) {
+          return ctx.rewrite!('/target');
+        }
+        return next();
+      });
+
+      app.use('/target', async (_ctx, next) => {
+        scopedRuns += 1;
+        return next();
+      });
+
+      app.get('/target', () => text('ok'));
+
+      await app.dispatch('http://localhost/gateway');
+      expect(scopedRuns).toBe(1);
+    });
+  });
+
+  describe('routing', () => {
+    test('returns 404 when the rewritten path has no handler', async () => {
+      const app = new Application();
+      app.get('/gateway', (ctx) => ctx.rewrite!('/missing'));
+
+      const res = await app.dispatch('http://localhost/gateway');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('handler contract', () => {
+    test('rejects rewrite() after next() completes in the same handler', async () => {
+      const app = new Application();
+      app.get('/bad', async (ctx, next) => {
+        await next();
+        return await ctx.rewrite!('/other');
+      });
+      app.get('/other', () => text('other'));
+
+      const res = await app.dispatch('http://localhost/bad');
+      expect(res.status).toBe(500);
+    });
+
+    test('resets next/rewrite guards for handlers in a nested rewrite target', async () => {
+      const app = new Application();
+
+      app.get('/outer', (ctx) => ctx.rewrite!('/middle'));
+      app.get('/middle', (ctx) => ctx.rewrite!('/inner'));
+      app.get('/inner', (_ctx, next) => next());
+      app.get('/inner', () => text('inner'));
+
+      const res = await app.dispatch('http://localhost/outer');
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('inner');
+    });
+  });
+
+  describe('safety limits', () => {
+    test('detects rewrite loops', async () => {
+      const app = new Application({ maxRewriteDepth: 5 });
+      app.get('/a', (ctx) => ctx.rewrite!('/b'));
+      app.get('/b', (ctx) => ctx.rewrite!('/a'));
+
+      const res = await app.dispatch('http://localhost/a');
+      expect(res.status).toBe(508);
+    });
+
+    test('enforces maxRewriteDepth', async () => {
+      const app = new Application({ maxRewriteDepth: 1 });
+      app.get('/a', (ctx) => ctx.rewrite!('/b'));
+      app.get('/b', (ctx) => ctx.rewrite!('/c'));
+      app.get('/c', () => text('c'));
+
+      const res = await app.dispatch('http://localhost/a');
+      expect(res.status).toBe(508);
+    });
   });
 });

--- a/packages/web-router/src/application.ts
+++ b/packages/web-router/src/application.ts
@@ -2,9 +2,9 @@
  * @fileoverview Application domain object - HTTP request/response lifecycle management
  */
 import { callContext } from '@web-widget/context/server';
-import { compose } from '@web-widget/helpers';
 import { normalizeForwardedRequest } from '@web-widget/helpers/proxy';
 import { createHttpError } from '@web-widget/helpers/error';
+import { runMatchedStack } from './stack';
 import { Context } from './context';
 import type { Router } from './router';
 import {
@@ -23,7 +23,23 @@ import type {
   MiddlewareHandler,
   NotFoundHandler,
 } from './types';
-import { getPath, getPathNoStrict } from './url';
+import {
+  DEFAULT_MAX_REWRITE_DEPTH,
+  assertRewriteAllowed,
+  filterHandlersForRewrite,
+  getRewriteState,
+  popRewriteDestination,
+  pushRewriteDestination,
+  resolveRewriteDestination,
+  rewritePathKey,
+  type RewriteState,
+} from './rewrite';
+import {
+  getPathForRequest,
+  getPathForUrl,
+  getPathNoStrictForRequest,
+  getPathNoStrictForUrl,
+} from './url';
 
 type Methods = (typeof METHODS)[number];
 
@@ -52,11 +68,33 @@ const notFoundHandler = () => {
   });
 };
 
+function assertHandlerResponse(res: void | Response | undefined): Response {
+  if (!res) {
+    throw new Error(
+      'Response is not finalized. You may forget returning Response object or `return next()`.'
+    );
+  }
+  if (!(res instanceof Response)) {
+    throw new TypeError('Response must be an instance of Response.');
+  }
+  return res;
+}
+
 const errorHandler = (error: unknown) => {
   console.error(error);
-  const message = 'Internal Server Error';
+  const status =
+    error &&
+    typeof error === 'object' &&
+    typeof (error as HTTPException).status === 'number' &&
+    (error as HTTPException).status! >= 400
+      ? (error as HTTPException).status!
+      : 500;
+  const message =
+    status < 500 && error instanceof Error
+      ? error.message
+      : 'Internal Server Error';
   return new Response(message, {
-    status: 500,
+    status,
   });
 };
 
@@ -81,6 +119,11 @@ export interface ApplicationOptions<E extends Env> {
    * X-Forwarded-Host and X-Forwarded-Proto. Otherwise, the client may provide any value.
    */
   proxy?: boolean;
+  /**
+   * Maximum nested `rewrite()` depth per request (cycle guard).
+   * @default 10
+   */
+  maxRewriteDepth?: number;
 }
 
 class Application<
@@ -93,6 +136,8 @@ class Application<
   */
   router!: Router<MiddlewareHandler>;
   readonly getPath: GetPath<E>;
+  readonly #strict: boolean;
+  readonly #usesCustomGetPath: boolean;
 
   constructor(options: ApplicationOptions<E> = {}) {
     super();
@@ -119,8 +164,11 @@ class Application<
     const routerType = options.routerType ?? getDefaultRouterType();
     delete options.strict;
     delete options.routerType;
-    // Object.assign(this, options);
-    this.getPath = strict ? (options.getPath ?? getPath) : getPathNoStrict;
+    this.#strict = strict;
+    this.#usesCustomGetPath = !!options.getPath;
+    this.getPath = strict
+      ? (options.getPath ?? getPathForRequest)
+      : getPathNoStrictForRequest;
 
     // Choose router based on configuration
     if (options.router) {
@@ -133,9 +181,12 @@ class Application<
     }
 
     this.#proxy = !!options.proxy;
+    this.#maxRewriteDepth =
+      options.maxRewriteDepth ?? DEFAULT_MAX_REWRITE_DEPTH;
   }
 
   #proxy: boolean = false;
+  #maxRewriteDepth: number = DEFAULT_MAX_REWRITE_DEPTH;
   #notFoundHandler: NotFoundHandler = notFoundHandler;
   #errorHandler: ErrorHandler = errorHandler;
 
@@ -169,6 +220,36 @@ class Application<
     return this.router.match(method, path);
   }
 
+  #pathForUrl(url: URL, env?: E['Bindings']): string {
+    if (this.#usesCustomGetPath) {
+      return this.getPath(new Request(url.href), { env });
+    }
+    return this.#strict ? getPathForUrl(url) : getPathNoStrictForUrl(url);
+  }
+
+  async #runMatchedStack(
+    context: Context,
+    method: string,
+    path: string,
+    rewriteState: RewriteState,
+    options: {
+      recordInitialHandlers: boolean;
+      filterGlobalHandlers?: boolean;
+    }
+  ): Promise<Response> {
+    let matched = this.#matchRoute(method, path);
+    if (options.filterGlobalHandlers) {
+      matched = filterHandlersForRewrite(matched, rewriteState);
+    }
+
+    const run = runMatchedStack(matched, {
+      rewriteState,
+      recordInitialHandlers: options.recordInitialHandlers,
+    });
+
+    return assertHandlerResponse(await run(context, this.#notFoundHandler));
+  }
+
   handler(
     request: Request,
     env: E['Bindings'] | undefined = Object.create(null),
@@ -189,34 +270,25 @@ class Application<
     }
 
     const path = this.getPath(request, { env });
-    const handlers = this.#matchRoute(method, path);
 
     const context = new Context(request, {
       env,
       executionContext,
     });
 
-    const composed = compose<(typeof handlers)[0], Context>(
-      handlers,
-      (handler) => {
-        context.params = handler[1];
-        context.pathname = handler[2];
-        return handler[0];
-      }
-    );
+    const rewriteState = getRewriteState(context);
+    context.rewrite = (destination) =>
+      this.#rewrite(context, destination, method, env, rewriteState);
 
     return (async () => {
       try {
-        const res = await composed(context, this.#notFoundHandler);
-        if (!res) {
-          throw new Error(
-            'Response is not finalized. You may forget returning Response object or `return next()`.'
-          );
-        }
-
-        if (!(res instanceof Response)) {
-          throw new TypeError('Response must be an instance of Response.');
-        }
+        const res = await this.#runMatchedStack(
+          context,
+          method,
+          path,
+          rewriteState,
+          { recordInitialHandlers: true }
+        );
 
         if (
           res.status >= 400 &&
@@ -291,6 +363,46 @@ class Application<
   ) => {
     return this.dispatch(input, requestInit, env, executionContext);
   };
+
+  async #rewrite(
+    context: Context,
+    destination: string | URL,
+    method: string,
+    env: E['Bindings'] | undefined,
+    state: RewriteState
+  ): Promise<Response> {
+    assertRewriteAllowed(state);
+    state._rewriteCalled = true;
+
+    if (state._depth >= this.#maxRewriteDepth) {
+      throw createHttpError(508, 'Maximum rewrite depth exceeded');
+    }
+
+    const resolved = resolveRewriteDestination(destination, context.request);
+    const pathKey = rewritePathKey(resolved);
+
+    pushRewriteDestination(state, pathKey);
+
+    const internalPath = this.#pathForUrl(resolved, env);
+
+    state._depth += 1;
+    const previousRewriteCalled = state._rewriteCalled;
+    const previousNextCompleted = state._nextCompleted;
+    state._rewriteCalled = false;
+    state._nextCompleted = false;
+
+    try {
+      return await this.#runMatchedStack(context, method, internalPath, state, {
+        recordInitialHandlers: false,
+        filterGlobalHandlers: true,
+      });
+    } finally {
+      popRewriteDestination(state);
+      state._depth -= 1;
+      state._rewriteCalled = previousRewriteCalled;
+      state._nextCompleted = previousNextCompleted;
+    }
+  }
 
   async #normalizeHTTPException(error: unknown): Promise<HTTPException> {
     // If it's an Error object, preserve original stack trace

--- a/packages/web-router/src/context.ts
+++ b/packages/web-router/src/context.ts
@@ -45,6 +45,9 @@ export class Context<E extends Env = Env> implements FetchContext {
   data?: unknown;
   error?: HTTPException;
 
+  /** Bound per request in Application.handler when rewrite is available. */
+  rewrite?: FetchContext['rewrite'];
+
   constructor(request: Request, options?: ContextOptions<E>) {
     this.request = request;
     this.#executionContext = options?.executionContext;

--- a/packages/web-router/src/rewrite.test.ts
+++ b/packages/web-router/src/rewrite.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'vitest';
+import { Context } from './context';
+import {
+  filterHandlersForRewrite,
+  getRewriteState,
+  hasExplicitSearch,
+  pushRewriteDestination,
+  popRewriteDestination,
+  resolveRewriteDestination,
+  rewritePathKey,
+} from './rewrite';
+import type { MiddlewareHandler } from './types';
+
+describe('rewrite utilities', () => {
+  describe('resolveRewriteDestination', () => {
+    const request = new Request('http://localhost/v1/foo?bar=1');
+
+    test('preserves query when destination has no search', () => {
+      const url = resolveRewriteDestination('/internal/foo', request);
+      expect(url.pathname).toBe('/internal/foo');
+      expect(url.search).toBe('?bar=1');
+    });
+
+    test('uses explicit query from destination string', () => {
+      const url = resolveRewriteDestination('/internal/foo?baz=2', request);
+      expect(url.search).toBe('?baz=2');
+    });
+
+    test('uses explicit query from URL object', () => {
+      const url = resolveRewriteDestination(
+        new URL('/internal/foo?baz=2', request.url),
+        request
+      );
+      expect(url.search).toBe('?baz=2');
+    });
+
+    test('rejects cross-origin destination', () => {
+      expect(() =>
+        resolveRewriteDestination('https://evil.test/internal', request)
+      ).toThrow(/same-origin/i);
+    });
+  });
+
+  describe('hasExplicitSearch', () => {
+    test('detects query in string', () => {
+      expect(hasExplicitSearch('/a')).toBe(false);
+      expect(hasExplicitSearch('/a?x=1')).toBe(true);
+    });
+
+    test('detects query on URL', () => {
+      expect(hasExplicitSearch(new URL('http://localhost/a'))).toBe(false);
+      expect(hasExplicitSearch(new URL('http://localhost/a?q=1'))).toBe(true);
+    });
+  });
+
+  describe('rewritePathKey', () => {
+    test('includes pathname and search', () => {
+      expect(rewritePathKey(new URL('http://localhost/internal?x=1'))).toBe(
+        '/internal?x=1'
+      );
+    });
+  });
+
+  describe('pushRewriteDestination / popRewriteDestination', () => {
+    test('detects loops with visited set', () => {
+      const state = getRewriteState(
+        new Context(new Request('http://localhost/'))
+      );
+      pushRewriteDestination(state, '/a');
+      pushRewriteDestination(state, '/b');
+      expect(() => pushRewriteDestination(state, '/a')).toThrow(/loop/i);
+      popRewriteDestination(state);
+      popRewriteDestination(state);
+      pushRewriteDestination(state, '/a');
+      expect(state._rewriteVisited.has('/a')).toBe(true);
+    });
+  });
+
+  describe('filterHandlersForRewrite', () => {
+    test('skips executed global (*) handlers only', () => {
+      const state = getRewriteState(
+        new Context(new Request('http://localhost/'))
+      );
+      const global: MiddlewareHandler = async () => new Response();
+      const scoped: MiddlewareHandler = async () => new Response();
+      state._initialExecutedHandlers.add(global);
+      state._hasRecordedInitialHandlers = true;
+
+      const filtered = filterHandlersForRewrite(
+        [
+          [global, {}, '*'],
+          [scoped, {}, '/api'],
+        ],
+        state
+      );
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0][0]).toBe(scoped);
+    });
+  });
+});

--- a/packages/web-router/src/rewrite.ts
+++ b/packages/web-router/src/rewrite.ts
@@ -1,0 +1,167 @@
+/**
+ * @fileoverview Runtime URL rewrite utilities
+ */
+import { createHttpError } from '@web-widget/helpers/error';
+import type { Context } from './context';
+import type { Router } from './router';
+import type { MiddlewareHandler, MiddlewareNext } from './types';
+
+/** Default maximum nested rewrite depth per request. */
+export const DEFAULT_MAX_REWRITE_DEPTH = 10;
+
+/** Route pattern for app-wide middleware registered via `app.use('*', ...)`. */
+export const GLOBAL_ROUTE_PATTERN = '*';
+
+/** @internal Per-request rewrite tracking (stored in WeakMap, not on `context.state`). */
+export interface RewriteState {
+  /** Handlers already run on the initial (external) route match — skipped on rewrite. */
+  readonly _initialExecutedHandlers: WeakSet<MiddlewareHandler>;
+  /** Whether any handler from the initial chain has been recorded. */
+  _hasRecordedInitialHandlers: boolean;
+  _depth: number;
+  /** Destinations visited in the current rewrite branch (stack + set for O(1) lookup). */
+  readonly _rewriteStack: string[];
+  readonly _rewriteVisited: Set<string>;
+  _nextCompleted: boolean;
+  _rewriteCalled: boolean;
+}
+
+const rewriteStateByContext = new WeakMap<Context, RewriteState>();
+
+export function getRewriteState(context: Context): RewriteState {
+  let state = rewriteStateByContext.get(context);
+  if (!state) {
+    state = {
+      _initialExecutedHandlers: new WeakSet(),
+      _hasRecordedInitialHandlers: false,
+      _depth: 0,
+      _rewriteStack: [],
+      _rewriteVisited: new Set(),
+      _nextCompleted: false,
+      _rewriteCalled: false,
+    };
+    rewriteStateByContext.set(context, state);
+  }
+  return state;
+}
+
+export function hasExplicitSearch(destination: string | URL): boolean {
+  if (typeof destination === 'string') {
+    const queryIndex = destination.indexOf('?');
+    return queryIndex !== -1;
+  }
+  return destination.search !== '';
+}
+
+/**
+ * Resolve rewrite destination: same-origin only; merge query per RFC.
+ */
+export function resolveRewriteDestination(
+  destination: string | URL,
+  request: Request
+): URL {
+  const base = new URL(request.url);
+  const resolved =
+    destination instanceof URL
+      ? new URL(destination)
+      : new URL(destination, base);
+
+  if (resolved.origin !== base.origin) {
+    throw createHttpError(
+      400,
+      'Rewrite destination must be same-origin or relative'
+    );
+  }
+
+  if (!hasExplicitSearch(destination)) {
+    resolved.search = base.search;
+  }
+
+  return resolved;
+}
+
+export function rewritePathKey(url: URL): string {
+  return url.pathname + url.search;
+}
+
+export function assertRewriteAllowed(state: RewriteState): void {
+  if (state._nextCompleted) {
+    throw createHttpError(
+      500,
+      'Cannot rewrite() after next() has completed in the same handler'
+    );
+  }
+  if (state._rewriteCalled) {
+    throw createHttpError(
+      500,
+      'Cannot call rewrite() or next() again after rewrite() in the same handler'
+    );
+  }
+}
+
+export function trackInitialExecutedHandler(
+  state: RewriteState,
+  handler: MiddlewareHandler
+): void {
+  state._initialExecutedHandlers.add(handler);
+  state._hasRecordedInitialHandlers = true;
+}
+
+export function createGuardedNext(
+  state: RewriteState,
+  next: MiddlewareNext
+): MiddlewareNext {
+  return async () => {
+    if (state._rewriteCalled) {
+      throw createHttpError(
+        500,
+        'Cannot call next() after rewrite() in the same handler'
+      );
+    }
+    const response = await next();
+    state._nextCompleted = true;
+    return response;
+  };
+}
+
+export function pushRewriteDestination(
+  state: RewriteState,
+  pathKey: string
+): void {
+  if (state._rewriteVisited.has(pathKey)) {
+    throw createHttpError(508, 'Rewrite loop detected');
+  }
+  state._rewriteStack.push(pathKey);
+  state._rewriteVisited.add(pathKey);
+}
+
+export function popRewriteDestination(state: RewriteState): void {
+  const pathKey = state._rewriteStack.pop();
+  if (pathKey) {
+    state._rewriteVisited.delete(pathKey);
+  }
+}
+
+/**
+ * Skip only global (`*`) handlers already run on the initial external match.
+ * Route-scoped handlers for the rewrite target must still run (incl. cycle targets).
+ */
+export function filterHandlersForRewrite<T extends MiddlewareHandler>(
+  handlers: ReturnType<Router<T>['match']>,
+  state: RewriteState
+): ReturnType<Router<T>['match']> {
+  if (!state._hasRecordedInitialHandlers) {
+    return handlers;
+  }
+  const executed = state._initialExecutedHandlers;
+  const filtered: ReturnType<Router<T>['match']> = [];
+  for (let i = 0; i < handlers.length; i++) {
+    const entry = handlers[i];
+    const pattern = entry[2];
+    if (pattern === GLOBAL_ROUTE_PATTERN && executed.has(entry[0])) {
+      continue;
+    }
+    filtered.push(entry);
+  }
+  return filtered;
+}

--- a/packages/web-router/src/stack.test.ts
+++ b/packages/web-router/src/stack.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest';
+import { Context } from './context';
+import { getRewriteState } from './rewrite';
+import { runMatchedStack } from './stack';
+import type { MiddlewareHandler } from './types';
+
+describe('runMatchedStack', () => {
+  describe('context binding', () => {
+    test('sets params and pathname when a handler is entered', async () => {
+      const context = new Context(new Request('http://localhost/v1/x'));
+      const seen: string[] = [];
+
+      const run = runMatchedStack([
+        [
+          async (ctx) => {
+            seen.push(`${ctx.pathname}:${ctx.params.id}`);
+            return new Response('ok');
+          },
+          { id: '42' },
+          '/v1/:id',
+        ],
+      ]);
+
+      const res = await run(context, () => new Response('404'));
+      expect(res.status).toBe(200);
+      expect(seen).toEqual(['/v1/:id:42']);
+    });
+  });
+
+  describe('rewrite integration', () => {
+    test('records handlers that were actually entered on the initial stack', async () => {
+      const context = new Context(new Request('http://localhost/'));
+      const state = getRewriteState(context);
+      const global: MiddlewareHandler = async (_ctx, next) => next();
+      const route: MiddlewareHandler = async () => new Response('route');
+
+      const run = runMatchedStack(
+        [
+          [global, {}, '*'],
+          [route, { id: '1' }, '/:id'],
+        ],
+        { rewriteState: state, recordInitialHandlers: true }
+      );
+
+      await run(context, () => new Response('404'));
+
+      expect(state._hasRecordedInitialHandlers).toBe(true);
+      expect(state._initialExecutedHandlers.has(global)).toBe(true);
+      expect(state._initialExecutedHandlers.has(route)).toBe(true);
+    });
+
+    test('forbids next() after rewrite() in the same handler frame', async () => {
+      const context = new Context(new Request('http://localhost/'));
+      const state = getRewriteState(context);
+      state._rewriteCalled = true;
+
+      const run = runMatchedStack(
+        [[async (_ctx, next) => await next(), {}, '*']],
+        { rewriteState: state }
+      );
+
+      await expect(run(context, () => new Response('404'))).rejects.toThrow(
+        /after rewrite/i
+      );
+    });
+  });
+});

--- a/packages/web-router/src/stack.ts
+++ b/packages/web-router/src/stack.ts
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Run matched route handler stacks with lazy execution (no per-handler wrapping).
+ */
+import type { Context } from './context';
+import type { Result } from './router/base';
+import {
+  createGuardedNext,
+  trackInitialExecutedHandler,
+  type RewriteState,
+} from './rewrite';
+import type {
+  MiddlewareHandler,
+  MiddlewareNext,
+  NotFoundHandler,
+} from './types';
+
+export type MatchedStack = Result<MiddlewareHandler>;
+
+export interface RunMatchedStackOptions {
+  rewriteState?: RewriteState;
+  /** Record handlers for rewrite global-middleware filtering (initial external chain only). */
+  recordInitialHandlers?: boolean;
+}
+
+export type MatchedStackRunner = (
+  context: Context,
+  notFound: NotFoundHandler
+) => Promise<Response>;
+
+/**
+ * Build a runner for router match tuples (handler, params, pattern).
+ *
+ * Guards and context binding run only when a handler is actually entered,
+ * unlike `compose(..., each)` which maps the full list up front.
+ */
+export function runMatchedStack(
+  matched: MatchedStack,
+  options: RunMatchedStackOptions = {}
+): MatchedStackRunner {
+  const { rewriteState, recordInitialHandlers = false } = options;
+
+  return (context, notFound) => {
+    let index = -1;
+    return runAt(0);
+
+    async function runAt(i: number): Promise<Response> {
+      if (i <= index) {
+        throw new Error('next() called multiple times.');
+      }
+      index = i;
+
+      if (i < matched.length) {
+        const [handler, params, pathname] = matched[i];
+        context.params = params;
+        context.pathname = pathname;
+
+        if (recordInitialHandlers && rewriteState) {
+          trackInitialExecutedHandler(rewriteState, handler);
+        }
+
+        const advance: MiddlewareNext = () => runAt(i + 1);
+        const next: MiddlewareNext = rewriteState
+          ? createGuardedNext(rewriteState, advance)
+          : advance;
+
+        return await handler(context, next);
+      }
+
+      if (i === matched.length) {
+        return notFound(context);
+      }
+
+      return new Response(null, {
+        status: 404,
+        statusText: 'Not Found',
+      });
+    }
+  };
+}

--- a/packages/web-router/src/url.test.ts
+++ b/packages/web-router/src/url.test.ts
@@ -1,58 +1,86 @@
-import { getPath, getPathNoStrict, getQueryStrings } from './url';
+import {
+  getPathForRequest,
+  getPathForUrl,
+  getPathNoStrictForRequest,
+  getPathNoStrictForUrl,
+  getQueryStringForHref,
+} from './url';
 
 describe('url', () => {
-  describe('getPath', () => {
-    test('getPath - no trailing slash', () => {
-      let path = getPath(new Request('https://example.com/'));
+  describe('getPathForRequest', () => {
+    test('no trailing slash', () => {
+      let path = getPathForRequest(new Request('https://example.com/'));
       expect(path).toBe('/');
-      path = getPath(new Request('https://example.com/hello'));
+      path = getPathForRequest(new Request('https://example.com/hello'));
       expect(path).toBe('/hello');
-      path = getPath(new Request('https://example.com/hello/hey'));
+      path = getPathForRequest(new Request('https://example.com/hello/hey'));
       expect(path).toBe('/hello/hey');
-      path = getPath(new Request('https://example.com/hello?name=foo'));
+      path = getPathForRequest(
+        new Request('https://example.com/hello?name=foo')
+      );
       expect(path).toBe('/hello');
-      path = getPath(
+      path = getPathForRequest(
         new Request('https://example.com/hello/hey?name=foo&name=bar')
       );
       expect(path).toBe('/hello/hey');
     });
 
-    test('getPath - with trailing slash', () => {
-      let path = getPath(new Request('https://example.com/hello/'));
+    test('with trailing slash', () => {
+      let path = getPathForRequest(new Request('https://example.com/hello/'));
       expect(path).toBe('/hello/');
-      path = getPath(new Request('https://example.com/hello/hey/'));
+      path = getPathForRequest(new Request('https://example.com/hello/hey/'));
       expect(path).toBe('/hello/hey/');
     });
   });
 
-  describe('getQueryStrings', () => {
-    test('getQueryStrings', () => {
-      let qs = getQueryStrings(
+  describe('getQueryStringForHref', () => {
+    test('extracts search from href', () => {
+      let qs = getQueryStringForHref(
         'https://example.com/hello?name=foo&name=bar&age=20'
       );
       expect(qs).toBe('?name=foo&name=bar&age=20');
-      qs = getQueryStrings('https://example.com/hello?');
+      qs = getQueryStringForHref('https://example.com/hello?');
       expect(qs).toBe('?');
-      qs = getQueryStrings('https://example.com/hello');
+      qs = getQueryStringForHref('https://example.com/hello');
       expect(qs).toBe('');
-      // Allows to contain hash
-      qs = getQueryStrings(
+      qs = getQueryStringForHref(
         'https://example.com/hello?name=foo&name=bar&age=20#hash'
       );
       expect(qs).toBe('?name=foo&name=bar&age=20#hash');
     });
   });
 
-  describe('getPathNoStrict', () => {
-    test('getPathNoStrict - no strict is false', () => {
-      let path = getPathNoStrict(new Request('https://example.com/hello/'));
+  describe('getPathForUrl', () => {
+    test('matches getPathForRequest for the same URL', () => {
+      const url = new URL('https://example.com/hello/hey?name=foo');
+      expect(getPathForUrl(url)).toBe(
+        getPathForRequest(new Request('https://example.com/hello/hey?name=foo'))
+      );
+    });
+
+    test('getPathNoStrictForUrl strips trailing slash', () => {
+      expect(getPathNoStrictForUrl(new URL('https://example.com/hello/'))).toBe(
+        '/hello'
+      );
+    });
+  });
+
+  describe('getPathNoStrictForRequest', () => {
+    test('strips trailing slash when strict is false', () => {
+      let path = getPathNoStrictForRequest(
+        new Request('https://example.com/hello/')
+      );
       expect(path).toBe('/hello');
-      path = getPathNoStrict(new Request('https://example.com/hello/hey/'));
+      path = getPathNoStrictForRequest(
+        new Request('https://example.com/hello/hey/')
+      );
       expect(path).toBe('/hello/hey');
     });
 
-    test('getPathNoStrict - return `/` even if strict is false', () => {
-      const path = getPathNoStrict(new Request('https://example.com/'));
+    test('returns `/` for root', () => {
+      const path = getPathNoStrictForRequest(
+        new Request('https://example.com/')
+      );
       expect(path).toBe('/');
     });
   });

--- a/packages/web-router/src/url.ts
+++ b/packages/web-router/src/url.ts
@@ -1,22 +1,36 @@
 /**
  * @fileoverview URL processing utility functions
  */
-export const getPath = (request: Request): string => {
+
+function extractPathname(url: string): string {
   // Optimized: RegExp is faster than indexOf() + slice()
-  const match = request.url.match(/^https?:\/\/[^/]+(\/[^?]*)/);
+  const match = url.match(/^https?:\/\/[^/]+(\/[^?]*)/);
   return match ? match[1] : '';
+}
+
+function normalizeTrailingSlash(path: string): string {
+  return path.length > 1 && path[path.length - 1] === '/'
+    ? path.slice(0, -1)
+    : path;
+}
+
+export const getPathForRequest = (request: Request): string => {
+  return extractPathname(request.url);
 };
 
-export const getQueryStrings = (url: string): string => {
-  const queryIndex = url.indexOf('?', 8);
-  return queryIndex === -1 ? '' : '?' + url.slice(queryIndex + 1);
+export const getPathForUrl = (url: URL): string => {
+  return extractPathname(url.href);
 };
 
-export const getPathNoStrict = (request: Request): string => {
-  const result = getPath(request);
+export const getQueryStringForHref = (href: string): string => {
+  const queryIndex = href.indexOf('?', 8);
+  return queryIndex === -1 ? '' : '?' + href.slice(queryIndex + 1);
+};
 
-  // if strict routing is false => `/hello/hey/` and `/hello/hey` are treated the same
-  return result.length > 1 && result[result.length - 1] === '/'
-    ? result.slice(0, -1)
-    : result;
+export const getPathNoStrictForRequest = (request: Request): string => {
+  return normalizeTrailingSlash(getPathForRequest(request));
+};
+
+export const getPathNoStrictForUrl = (url: URL): string => {
+  return normalizeTrailingSlash(getPathForUrl(url));
 };

--- a/rfcs/rewrite.zh.md
+++ b/rfcs/rewrite.zh.md
@@ -1,0 +1,169 @@
+# RFC：运行时 Rewrite（内部 URL 重写）
+
+| 字段     | 值                                                                    |
+| -------- | --------------------------------------------------------------------- |
+| 状态     | Draft                                                                 |
+| 作者     | @tangbin（草案）                                                      |
+| 创建日期 | 2026-05-20                                                            |
+| 影响范围 | `@web-widget/web-router`、`@web-widget/schema`、`@web-widget/helpers` |
+
+## 摘要
+
+在**不改变浏览器地址栏 URL** 的前提下，将请求在服务端改由另一条内部路径（同源）处理，由对应的 Route / Middleware 生成最终响应。
+
+本 RFC 界定**运行时、可编程**的 rewrite 设计，不包含声明式配置（如 `next.config.js` 的 `rewrites`）、构建期路由表改写或平台配置文件。
+
+```ts
+return context.rewrite(new URL('/internal', request.url));
+```
+
+## 动机
+
+### 与 Redirect 的区别
+
+|            | Rewrite                      | Redirect（已有 `redirect()`） |
+| ---------- | ---------------------------- | ----------------------------- |
+| 浏览器 URL | 不变                         | 变为 `Location` 目标          |
+| 路由       | 服务端重新匹配内部路径       | 客户端发起新请求              |
+| 典型场景   | 门面路径、实验分流、渐进迁移 | 永久跳转、登录重定向          |
+
+项目已有 `redirect()` 与对外 `proxy`，缺少**框架级内部路由重写**。自行 `dispatch` 二次请求易导致 params、中间件顺序、错误处理与框架行为不一致。
+
+### 典型用例
+
+- 对外路径与对内路由解耦（如 `/v1/*` → `/internal/*`）
+- 结合 flags / cookie 分流到不同页面实现
+- 保留对外 URL 的审计与 SEO，对内走新 Route（含 SSR）
+
+### 非目标
+
+- 声明式 rewrites 配置、构建期 routemap 改写
+- rewrite 到外部 origin（归 `@web-widget/helpers/proxy`）
+- rewrite 到 Action 端点
+- 客户端 `context.rewrite()`
+
+## 设计约束
+
+当前 Web Router 对每个请求**只匹配一次路由**再进入 handler 链；`redirect()` 返回的 `Response` 不会触发重新匹配。Rewrite 要在**同一请求生命周期内**改由另一条内部路径完成 handler 链，并把该链路的 **`Response` 交回**给调用方（与 `next()` 交给上游的性质相同），而非 Context 上的薄封装。
+
+## 目标
+
+- 提供 `context.rewrite(destination)`：内部改由 `destination` 匹配并执行对应模块，**返回该链路的 `Response`**
+- `context.request` 始终表示**对外 URL**（与地址栏一致）
+- 返回的 `Response` 与 `next()` 一样，可原样 `return`、可先改 headers 再 `return`、可由外层 middleware 继续加工
+
+## 公开 API
+
+在既有 `FetchContext`（含 `request`、`params`、`state` 等）上**新增**：
+
+```ts
+interface FetchContext {
+  /**
+   * 内部重写到 destination（相对路径相对于 request.url 解析）。
+   * 返回目标路径 handler 链的 Response，用法同 next()，见下文「返回值」。
+   */
+  rewrite(destination: string | URL): Response | Promise<Response>;
+}
+```
+
+## 核心语义
+
+### 对外 URL 与对内路由
+
+- 业务继续以既有 `context.request` 为准（鉴权、日志、canonical）；rewrite 不改变其表示对外 URL 的语义。
+- 框架在内部根据 `destination` 做路由匹配并执行目标链；匹配用 `params` 随目标路径更新。
+
+### 返回值与中间件模型
+
+`rewrite()` 在内部按 `destination` **重新匹配并跑完**该路径上的 handler 链（Route、该路径 middleware 等），得到一条真实的 `Response`，再交还给调用方。对该返回值的处理方式与 `await next()` **相同**：
+
+- 可直接 `return await ctx.rewrite(...)`
+- 可先改 headers / body 再 `return`
+- 外层 middleware 在 `const res = await next()` 中拿到的，可以是内层 `rewrite()` 产生并经内层加工后的 `Response`
+
+与 `redirect()` 的区别在于：`redirect()` 返回的 3xx 会改变浏览器后续请求；`rewrite()` 返回的是**内部路由链的实质响应**（通常 2xx 页面等），浏览器 URL 仍为 `context.request`。
+
+| 能力         | 客户端 URL | 返回的 `Response` 含义              |
+| ------------ | ---------- | ----------------------------------- |
+| `next()`     | 不变       | 当前栈下游链路的处理结果            |
+| `rewrite()`  | 不变       | **目标路径**上 handler 链的处理结果 |
+| `redirect()` | 改变       | 指示客户端跳转的 3xx                |
+
+### 重新匹配
+
+`rewrite()` 触发时：
+
+1. 按 `destination` 匹配路由；目标链路上的 handler 使用匹配后的 `params`（`context.request` 仍表示对外 URL）
+2. 执行该路径上的 handler 链直至得到 `Response`
+3. **不**默认重跑进入本次请求时已在全局层执行过的 middleware
+
+### 与 `next()` 的关系
+
+- 在**当前 handler** 内，`rewrite()` 与 `next()` 二选一：前者把「后续处理」委托给**另一条路径的链**，后者委托给**当前路径的下游**
+- `return ctx.rewrite(...)` 之后不应再对**当前栈**调用 `next()`
+- 已在 `await next()` 拿到 `Response` 之后再 `rewrite`：语义冲突，应拒绝
+
+### Query
+
+遵循 `URL` 解析：`destination` 未带 search 时**保留**原请求 query；显式写在 `destination` 中的 query 优先。
+
+### 错误、安全与缓存
+
+- 重写目标不存在或抛错：与直接访问该路径一致，走现有 404 / fallback
+- 仅允许同源或相对 `destination`
+- 缓存与 `Vary` 以**对外 URL** 为基准
+- 须限制 rewrite 深度并检测环
+
+### SSR
+
+Rewrite 到 Route 时，应走与直接命中该 Route 相同的渲染与 layout 管道。
+
+## 与现有能力的关系
+
+| 能力                         | 关系                                            |
+| ---------------------------- | ----------------------------------------------- |
+| `redirect()`                 | 改变客户端 URL；不重新匹配                      |
+| `proxy` / `fetchWithProxy`   | 对外 origin；与内部 rewrite 职责分离            |
+| `dispatch(new Request(...))` | 手工 workaround；实现后文档引导改用 `rewrite()` |
+
+## 行业参考
+
+| 框架    | 做法                                                      |
+| ------- | --------------------------------------------------------- |
+| Next.js | `NextResponse.rewrite()`，返回 Response 形态，URL 栏不变  |
+| Astro   | `context.rewrite()`；可选 `originPathname` 表示改写前路径 |
+| 其它    | 多无一等 rewrite，或平台层 `fetch` 自建语义               |
+
+共性：`return` 结束当前 middleware/handler；区分对外 URL 与对内路径；少暴露 rewrite 链或第二个 `Request`。
+
+## 待探讨
+
+1. **`destination` 是否接受 `Request`**（携带自定义 headers 的 internal 请求）
+2. **全局 middleware 在 rewrite 后是否允许 opt-in 重跑**
+3. **与 `ApplicationOptions.proxy` 的先后顺序**（对外 URL 与 forwarded 头的一致性）
+4. **默认最大 rewrite 深度与环检测策略**（数值与错误响应形态）
+5. **是否在后续版本公开 `originPathname`**（对标 Astro，对比 `ctx.state`）
+
+## 示例
+
+```ts
+export const handler = defineMiddlewareHandler(async (ctx, next) => {
+  const url = new URL(ctx.request.url);
+  if (url.pathname.startsWith('/v1/')) {
+    const res = await ctx.rewrite(
+      new URL(url.pathname.replace(/^\/v1/, '/internal'), url)
+    );
+    res.headers.set('x-routed-by', 'v1-gateway');
+    return res;
+  }
+  return next();
+});
+```
+
+访问 `/v1/products/42` 时地址栏不变；响应体来自 `/internal/products/42` 的 Route，外层 middleware 仍可改写 headers 后返回。
+
+## 参考
+
+- [Next.js `NextResponse.rewrite`](https://nextjs.org/docs/app/api-reference/functions/next-response#rewrite)
+- [Astro `context.rewrite` / `originPathname`](https://docs.astro.build/en/reference/api-reference/#rewrite)
+- 项目内：`docs/helpers/redirect.md`


### PR DESCRIPTION
Add runtime internal URL rewrite: `context.rewrite(destination)` re-matches and runs the target route handler chain while keeping `context.request` (the browser URL) unchanged. Supports same-origin destinations, query merge, skipping already-run global (`*`) middleware, nested depth limits, and loop detection.