### PR TITLE
fix(node): HTTP/2 pseudo-headers compatibility for Vite 8 HTTPS dev

### DIFF
--- a/.changeset/fix-node-http2-incoming-headers.md
+++ b/.changeset/fix-node-http2-incoming-headers.md
@@ -1,0 +1,5 @@
+---
+'@web-widget/node': patch
+---
+
+Fix HTTP/2 dev server compatibility when converting Node `IncomingMessage` to Fetch `Request`: strip pseudo-headers (`:method`, `:path`, etc.) before building `Headers`, map `:authority` to `host`, and resolve request origin from `:authority` / `:scheme` with `defaultOrigin` protocol (e.g. Vite 8 HTTPS on non-443 ports). Workaround until upstream `@edge-runtime/node-utils` fixes land.

--- a/packages/node/src/adapter.ts
+++ b/packages/node/src/adapter.ts
@@ -7,11 +7,12 @@ import type {
 } from '@edge-runtime/node-utils';
 import {
   buildToFetchEvent,
-  buildToRequest,
   mergeIntoServerResponse,
   toOutgoingHeaders,
 } from '@edge-runtime/node-utils';
 import primitives from '@edge-runtime/primitives';
+
+import { buildToRequestWithHttp2Compat } from './incoming-request';
 
 type WebHandler = (
   req: Request,
@@ -86,7 +87,7 @@ function toMiddleware(
   webHandler: WebHandler,
   options: RequestOptions
 ): Middleware {
-  const toRequest = buildToRequest(dependencies);
+  const toRequest = buildToRequestWithHttp2Compat(dependencies);
   const toFetchEvent = buildToFetchEvent(dependencies);
   return async function middleware(incomingMessage, serverResponse, next) {
     try {
@@ -202,7 +203,7 @@ function buildToNodeHandler(
   dependencies: BuildDependencies,
   options: RequestOptions
 ) {
-  const toRequest = buildToRequest(dependencies);
+  const toRequest = buildToRequestWithHttp2Compat(dependencies);
   const toFetchEvent = buildToFetchEvent(dependencies);
   return function toNodeHandler(webHandler: WebHandler): NodeHandler {
     return (

--- a/packages/node/src/incoming-request.ts
+++ b/packages/node/src/incoming-request.ts
@@ -1,0 +1,122 @@
+import type { IncomingHttpHeaders } from 'node:http';
+import type { IncomingMessage } from 'node:http';
+import type {
+  BuildDependencies,
+  RequestOptions,
+} from '@edge-runtime/node-utils';
+import {
+  buildToHeaders,
+  buildToReadableStream,
+} from '@edge-runtime/node-utils';
+
+/**
+ * HTTP/2 pseudo-headers (e.g. `:method`, `:path`) are valid on Node
+ * IncomingMessage but invalid for Fetch API Headers.
+ */
+function isHttp2PseudoHeader(name: string): boolean {
+  return name.startsWith(':');
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * Strips HTTP/2 pseudo-headers and maps `:authority` to `host` when needed.
+ */
+export function sanitizeIncomingHttpHeaders(
+  headers: IncomingHttpHeaders
+): IncomingHttpHeaders {
+  const sanitized: IncomingHttpHeaders = {};
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (!isHttp2PseudoHeader(key)) {
+      sanitized[key] = value;
+    }
+  }
+
+  if (!sanitized.host) {
+    const authority = headerValue(headers[':authority']);
+    if (authority) {
+      sanitized.host = authority;
+    }
+  }
+
+  return sanitized;
+}
+
+/**
+ * Resolves the request origin for URL construction.
+ * Handles HTTP/2 where authority may only appear as `:authority`.
+ */
+export function computeRequestOrigin(
+  headers: IncomingHttpHeaders,
+  defaultOrigin: string
+): string {
+  const authority =
+    headerValue(headers.host) ?? headerValue(headers[':authority']);
+
+  if (!authority) {
+    return defaultOrigin;
+  }
+
+  let protocol = 'http';
+  if (defaultOrigin) {
+    try {
+      protocol = new URL(defaultOrigin).protocol.replace(':', '') || 'http';
+    } catch {
+      // keep default protocol
+    }
+  }
+
+  const scheme = headerValue(headers[':scheme']);
+  if (scheme === 'http' || scheme === 'https') {
+    protocol = scheme;
+  }
+
+  const [, port] = authority.split(':');
+  if (port === '443') {
+    protocol = 'https';
+  }
+
+  return `${protocol}://${authority}`;
+}
+
+/**
+ * Converts Node IncomingMessage to Fetch Request with HTTP/2 compatibility.
+ * Workaround for @edge-runtime/node-utils until upstream fixes land.
+ *
+ * @see https://github.com/web-widget/web-widget/issues/754
+ * @see https://github.com/vercel/edge-runtime/issues/1152
+ */
+export function buildToRequestWithHttp2Compat(dependencies: BuildDependencies) {
+  const toHeaders = buildToHeaders(dependencies);
+  const toReadableStream = buildToReadableStream(dependencies);
+  const { Request } = dependencies;
+
+  return function toRequest(
+    request: IncomingMessage,
+    options: RequestOptions
+  ): Request {
+    const base = computeRequestOrigin(request.headers, options.defaultOrigin);
+    const headers = sanitizeIncomingHttpHeaders(request.headers);
+
+    return new Request(
+      String(
+        request.url?.startsWith('//')
+          ? new URL(base + request.url)
+          : new URL(request.url || '/', base)
+      ),
+      {
+        method: request.method,
+        headers: toHeaders(headers),
+        body: !['HEAD', 'GET'].includes(request.method ?? '')
+          ? toReadableStream(request)
+          : null,
+      }
+    );
+  };
+}


### PR DESCRIPTION
## Summary
- Fix SSR failures on Vite 8 HTTPS dev (`Headers.append: ":method" is an invalid header name`) by stripping HTTP/2 pseudo-headers before building Fetch `Headers`.
- Map `:authority` to `host` and resolve request origin from `:authority` / `:scheme` with `defaultOrigin` protocol so `Request.url` is correct on non-443 HTTPS ports.
- Workaround at `@web-widget/node` layer until upstream `@edge-runtime/node-utils` fixes land ([vercel/edge-runtime#1152](https://github.com/vercel/edge-runtime/issues/1152)).
Fixes https://github.com/web-widget/web-widget/issues/754
## Test plan
- [ ] Enable `server.https` in a Vite 8 + `@web-widget/vite-plugin` SSR example
- [ ] Run `vite dev` and open an SSR route over HTTPS
- [ ] Confirm no `Headers.append: ":method"` error and SSR renders successfully
- [ ] Verify `Request.url` host/port matches the browser address (e.g. `https://localhost:5173/...`)