### PR TITLE
fix(web-router): realign route-derived context after rewrite

### DIFF
--- a/.changeset/tiny-geckos-teach.md
+++ b/.changeset/tiny-geckos-teach.md
@@ -1,0 +1,7 @@
+---
+'@web-widget/web-router': patch
+---
+
+Fix rewrite route context realignment so route-derived fields are reset before matching the rewritten target path.
+
+Add regression tests to cover target route context/meta/config alignment, non-render target cleanup, and chained rewrites.

--- a/packages/web-router/src/application.ts
+++ b/packages/web-router/src/application.ts
@@ -385,6 +385,10 @@ class Application<
 
     const internalPath = this.#pathForUrl(resolved, env);
 
+    // Rewrite switches the active route branch. Reset route-derived context
+    // so the target route can activate its own module/context consistently.
+    this.#resetRouteDerivedContext(context);
+
     state._depth += 1;
     const previousRewriteCalled = state._rewriteCalled;
     const previousNextCompleted = state._nextCompleted;
@@ -402,6 +406,29 @@ class Application<
       state._rewriteCalled = previousRewriteCalled;
       state._nextCompleted = previousNextCompleted;
     }
+  }
+
+  #resetRouteDerivedContext(context: Context): void {
+    const routeContext = context as Context & {
+      module?: unknown;
+      meta?: unknown;
+      render?: unknown;
+      html?: unknown;
+      renderOptions?: unknown;
+      renderer?: unknown;
+      data?: unknown;
+      error?: unknown;
+      _handler?: unknown;
+    };
+    routeContext.module = undefined;
+    routeContext.meta = undefined;
+    routeContext.render = undefined;
+    routeContext.html = undefined;
+    routeContext.renderOptions = undefined;
+    routeContext.renderer = undefined;
+    routeContext.data = undefined;
+    routeContext.error = undefined;
+    routeContext._handler = undefined;
   }
 
   async #normalizeHTTPException(error: unknown): Promise<HTTPException> {

--- a/packages/web-router/src/index.test.ts
+++ b/packages/web-router/src/index.test.ts
@@ -173,6 +173,221 @@ describe('create route context', () => {
   });
 });
 
+describe('rewrite route-derived context', () => {
+  test('should realign activated route context to rewritten target route', async () => {
+    let contextSeenInTargetMiddleware: RouteContext | undefined;
+    const routeAConfig = { namespace: 'route-a' };
+    const routeBConfig = { namespace: 'route-b' };
+
+    const app = WebRouter.fromManifest({
+      routes: [
+        {
+          pathname: '/a',
+          module: {
+            handler: {
+              GET: () => new Response('route-a'),
+            },
+            meta: { title: 'Route A' },
+            config: routeAConfig,
+            render: async () => '<div>route-a</div>',
+            default: () => null,
+          } as RouteModule,
+        },
+        {
+          pathname: '/b',
+          module: {
+            handler: {
+              GET: () => new Response('route-b'),
+            },
+            meta: { title: 'Route B' },
+            config: routeBConfig,
+            render: async () => '<div>route-b</div>',
+            default: () => null,
+          } as RouteModule,
+        },
+      ],
+      middlewares: [
+        {
+          pathname: '/a',
+          module: {
+            handler(context) {
+              return context.rewrite!('/b');
+            },
+          },
+        },
+        {
+          pathname: '*',
+          module: {
+            handler(context, next) {
+              contextSeenInTargetMiddleware = context as RouteContext;
+              return next();
+            },
+          },
+        },
+      ],
+    });
+
+    const response = await app.dispatch('http://localhost/a');
+
+    expect(response.status).toBe(200);
+    expect(contextSeenInTargetMiddleware).toBeDefined();
+    expect(contextSeenInTargetMiddleware!.pathname).toBe('/b');
+    expect(contextSeenInTargetMiddleware!.meta?.title).toBe('Route B');
+    expect((contextSeenInTargetMiddleware!.module as any)?.config).toEqual(
+      routeBConfig
+    );
+  });
+
+  test('should clear render-derived context when rewritten target has no render', async () => {
+    let contextSeenInTargetMiddleware: RouteContext | undefined;
+    const routeAConfig = { namespace: 'route-a' };
+    const routeBConfig = { namespace: 'route-b' };
+
+    const app = WebRouter.fromManifest({
+      routes: [
+        {
+          pathname: '/a',
+          module: {
+            handler: {
+              GET: () => new Response('route-a'),
+            },
+            meta: { title: 'Route A' },
+            config: routeAConfig,
+            render: async () => '<div>route-a</div>',
+            default: () => null,
+          } as RouteModule,
+        },
+        {
+          pathname: '/b',
+          module: {
+            handler: {
+              GET: () => new Response('route-b'),
+            },
+            config: routeBConfig,
+          } as RouteModule,
+        },
+      ],
+      middlewares: [
+        {
+          pathname: '/a',
+          module: {
+            handler(context) {
+              return context.rewrite!('/b');
+            },
+          },
+        },
+        {
+          pathname: '/b',
+          module: {
+            handler(context, next) {
+              contextSeenInTargetMiddleware = context as RouteContext;
+              return next();
+            },
+          },
+        },
+      ],
+    });
+
+    const response = await app.dispatch('http://localhost/a');
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('route-b');
+    expect(contextSeenInTargetMiddleware).toBeDefined();
+    expect(contextSeenInTargetMiddleware!.pathname).toBe('/b');
+    expect(contextSeenInTargetMiddleware!.meta).toBeUndefined();
+    expect(contextSeenInTargetMiddleware!.render).toBeUndefined();
+    expect(contextSeenInTargetMiddleware!.html).toBeUndefined();
+    expect(contextSeenInTargetMiddleware!.renderOptions).toBeUndefined();
+    expect((contextSeenInTargetMiddleware!.module as any)?.config).toEqual(
+      routeBConfig
+    );
+  });
+
+  test('should keep route-derived context aligned after chained rewrites', async () => {
+    let contextSeenInFinalMiddleware: RouteContext | undefined;
+    const routeCConfig = { namespace: 'route-c' };
+
+    const app = WebRouter.fromManifest({
+      routes: [
+        {
+          pathname: '/a',
+          module: {
+            handler: {
+              GET: () => new Response('route-a'),
+            },
+            meta: { title: 'Route A' },
+            config: { namespace: 'route-a' },
+            render: async () => '<div>route-a</div>',
+            default: () => null,
+          } as RouteModule,
+        },
+        {
+          pathname: '/b',
+          module: {
+            handler: {
+              GET: () => new Response('route-b'),
+            },
+            meta: { title: 'Route B' },
+            config: { namespace: 'route-b' },
+            render: async () => '<div>route-b</div>',
+            default: () => null,
+          } as RouteModule,
+        },
+        {
+          pathname: '/c',
+          module: {
+            handler: {
+              GET: () => new Response('route-c'),
+            },
+            meta: { title: 'Route C' },
+            config: routeCConfig,
+            render: async () => '<div>route-c</div>',
+            default: () => null,
+          } as RouteModule,
+        },
+      ],
+      middlewares: [
+        {
+          pathname: '/a',
+          module: {
+            handler(context) {
+              return context.rewrite!('/b');
+            },
+          },
+        },
+        {
+          pathname: '/b',
+          module: {
+            handler(context) {
+              return context.rewrite!('/c');
+            },
+          },
+        },
+        {
+          pathname: '/c',
+          module: {
+            handler(context, next) {
+              contextSeenInFinalMiddleware = context as RouteContext;
+              return next();
+            },
+          },
+        },
+      ],
+    });
+
+    const response = await app.dispatch('http://localhost/a');
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('route-c');
+    expect(contextSeenInFinalMiddleware).toBeDefined();
+    expect(contextSeenInFinalMiddleware!.pathname).toBe('/c');
+    expect(contextSeenInFinalMiddleware!.meta?.title).toBe('Route C');
+    expect((contextSeenInFinalMiddleware!.module as any)?.config).toEqual(
+      routeCConfig
+    );
+  });
+});
+
 describe('error handling', () => {
   const createTestRoute = async (
     routeModule: RouteModule


### PR DESCRIPTION
## Summary
- reset route-derived context fields before matching rewritten targets so middleware/handlers observe the rewritten route module state
- add regression tests for rewrite context realignment, non-render target cleanup, and chained rewrites
- add a patch changeset for `@web-widget/web-router`

## Test plan
- [x] `pnpm --filter @web-widget/web-router exec vitest run src/index.test.ts src/application.test.ts`
- [x] `pnpm --filter @web-widget/web-router exec vitest run src/index.test.ts -t \"rewrite route-derived context\"`
- [x] `pnpm --filter @web-widget/web-router exec vitest run src/index.test.ts`