### PR TITLE
docs(rfc): revise rewrite to mutable request + next() model

### DIFF
--- a/rfcs/rewrite.zh.md
+++ b/rfcs/rewrite.zh.md
@@ -1,20 +1,18 @@
 # RFC：运行时 Rewrite（内部 URL 重写）
 
-| 字段     | 值                                                                    |
-| -------- | --------------------------------------------------------------------- |
-| 状态     | Draft                                                                 |
-| 作者     | @tangbin（草案）                                                      |
-| 创建日期 | 2026-05-20                                                            |
-| 影响范围 | `@web-widget/web-router`、`@web-widget/schema`、`@web-widget/helpers` |
+状态：实施中
 
 ## 摘要
 
-在**不改变浏览器地址栏 URL** 的前提下，将请求在服务端改由另一条内部路径（同源）处理，由对应的 Route / Middleware 生成最终响应。
+在不改变浏览器地址栏 URL 的前提下，将服务端对内路由切换到另一条同源路径，由对应的 Route / Middleware 生成最终响应。
 
 本 RFC 界定**运行时、可编程**的 rewrite 设计，不包含声明式配置（如 `next.config.js` 的 `rewrites`）、构建期路由表改写或平台配置文件。
 
+典型用法：
+
 ```ts
-return context.rewrite(new URL('/internal', request.url));
+context.rewrite(new URL('/internal', context.request.url));
+return next();
 ```
 
 ## 动机
@@ -24,10 +22,10 @@ return context.rewrite(new URL('/internal', request.url));
 |            | Rewrite                      | Redirect（已有 `redirect()`） |
 | ---------- | ---------------------------- | ----------------------------- |
 | 浏览器 URL | 不变                         | 变为 `Location` 目标          |
-| 路由       | 服务端重新匹配内部路径       | 客户端发起新请求              |
+| 对内路由   | 切换 `context.request`       | 不适用（客户端发起新请求）    |
 | 典型场景   | 门面路径、实验分流、渐进迁移 | 永久跳转、登录重定向          |
 
-项目已有 `redirect()` 与对外 `proxy`，缺少**框架级内部路由重写**。自行 `dispatch` 二次请求易导致 params、中间件顺序、错误处理与框架行为不一致。
+项目已有 `redirect()` 与对外 `proxy`，缺少**框架级内部路由重写**。自行 `dispatch(new Request(...))` 易导致 params、中间件顺序、route 激活与错误处理不一致。
 
 ### 典型用例
 
@@ -42,117 +40,148 @@ return context.rewrite(new URL('/internal', request.url));
 - rewrite 到 Action 端点
 - 客户端 `context.rewrite()`
 
-## 设计约束
+## 核心抽象
 
-当前 Web Router 对每个请求**只匹配一次路由**再进入 handler 链；`redirect()` 返回的 `Response` 不会触发重新匹配。Rewrite 要在**同一请求生命周期内**改由另一条内部路径完成 handler 链，并把该链路的 **`Response` 交回**给调用方（与 `next()` 交给上游的性质相同），而非 Context 上的薄封装。
+`context.rewrite(destination)` 的本质是**更新 Context 的对内路由视图**，语义上等价于：
+
+```ts
+context.request = new Request(destination, context.request);
+```
+
+并附带框架必需的调度副作用（见下文「重新匹配」与「Route 激活」）。
+
+这与 Koa 的 `ctx.path = newPath` 同类：`rewrite` 之后，所有后续读取 `context.request.url` 的逻辑看到的都是**对内路径**。与 Koa 不同的是，Web Router 存在**被激活的路由模块**；`context.request` 改变后，`context.module` 及其衍生状态（`meta`、`html` 等）必须随之失效并在后续 handler 中按新路径重新激活。
+
+浏览器地址栏 URL 始终不变；通过 `context.originalRequest` 可以访问原始的请求（见「公开 API」）。
 
 ## 目标
 
-- 提供 `context.rewrite(destination)`：内部改由 `destination` 匹配并执行对应模块，**返回该链路的 `Response`**
-- `context.request` 始终表示**对外 URL**（与地址栏一致）
-- 返回的 `Response` 与 `next()` 一样，可原样 `return`、可先改 headers 再 `return`、可由外层 middleware 继续加工
+- 提供 `context.rewrite(destination)`：更新对内 `Request`，失效 route 状态，重新匹配尚未执行的 handler 栈
+- 典型模式为 `rewrite(...); return next()`，由后续栈经 `next()` 产生并回传 `Response`
+- `context.originalRequest` 始终指向客户端原始请求
+- 全局 middleware（`*`）在请求级只执行一次
 
 ## 公开 API
 
-在既有 `FetchContext`（含 `request`、`params`、`state` 等）上**新增**：
+在既有 `FetchContext` 上扩展：
 
 ```ts
 interface FetchContext {
   /**
-   * 内部重写到 destination（相对路径相对于 request.url 解析）。
-   * 返回目标路径 handler 链的 Response，用法同 next()，见下文「返回值」。
+   * 当前对内路由所用的 Request。
+   * rewrite 之后其 URL 为 destination；首次进入请求时为客户端原始 Request。
    */
-  rewrite(destination: string | URL): Response | Promise<Response>;
+  request: Request;
+
+  /**
+   * 客户端原始 Request（未来可能公开）。
+   * 始终指向本次 HTTP 请求进入框架时的 Request，rewrite 不改变此引用。
+   */
+  originalRequest?: Request;
+
+  /**
+   * 内部重写到 destination（相对路径相对于 context.request.url 解析）。
+   * 更新 context.request，失效 route 激活状态，并重新匹配剩余 handler 栈。
+   * 不返回 Response；应配合 return next() 使用。
+   */
+  rewrite(destination: string | URL): void;
 }
 ```
 
 ## 核心语义
 
-### 对外 URL 与对内路由
+### context.request 与 originalRequest
 
-- 业务继续以既有 `context.request` 为准（鉴权、日志、canonical）；rewrite 不改变其表示对外 URL 的语义。
-- 框架在内部根据 `destination` 做路由匹配并执行目标链；匹配用 `params` 随目标路径更新。
+| 字段                      | 含义                                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| `context.request`         | 当前**对内路由**所用的 `Request`；`rewrite` 后更新为 `new Request(destination, prev)` |
+| `context.originalRequest` | 客户端原始 `Request`；整个请求生命周期内不变                                          |
 
-### 返回值与中间件模型
+需要对外 URL（鉴权、日志、canonical、SEO、缓存键）时，应读取 `context.originalRequest.url`（或其在 `context.state` 中的等价快照），而非假设 `context.request.url` 与地址栏一致。
 
-`rewrite()` 在内部按 `destination` **重新匹配并跑完**该路径上的 handler 链（Route、该路径 middleware 等），得到一条真实的 `Response`，再交还给调用方。对该返回值的处理方式与 `await next()` **相同**：
+### 与 next() 的关系
 
-- 可直接 `return await ctx.rewrite(...)`
-- 可先改 headers / body 再 `return`
-- 外层 middleware 在 `const res = await next()` 中拿到的，可以是内层 `rewrite()` 产生并经内层加工后的 `Response`
+| 能力        | 作用                                                             |
+| ----------- | ---------------------------------------------------------------- |
+| `rewrite()` | 切换对内 `Request`，失效 route 状态，**重新匹配剩余 handler 栈** |
+| `next()`    | 在（可能已更新的）栈上继续执行下游 handler                       |
 
-与 `redirect()` 的区别在于：`redirect()` 返回的 3xx 会改变浏览器后续请求；`rewrite()` 返回的是**内部路由链的实质响应**（通常 2xx 页面等），浏览器 URL 仍为 `context.request`。
+规则：
 
-| 能力         | 客户端 URL | 返回的 `Response` 含义              |
-| ------------ | ---------- | ----------------------------------- |
-| `next()`     | 不变       | 当前栈下游链路的处理结果            |
-| `rewrite()`  | 不变       | **目标路径**上 handler 链的处理结果 |
-| `redirect()` | 改变       | 指示客户端跳转的 3xx                |
+- **允许且推荐**：`context.rewrite(...); return next()`
+- **禁止**：`await next()` 完成后再 `rewrite()`（与 Koa 一致，语义冲突）
+- **禁止**：`rewrite()` 后在不 re-match 的情况下继续旧路径的 handler 栈（由实现保证）
+
+`rewrite()` 不返回 `Response`。`Response` 由 `rewrite` 之后的新栈经 `next()` 产生，并可被外层 middleware 读取、修改后返回。
 
 ### 重新匹配
 
 `rewrite()` 触发时：
 
-1. 按 `destination` 匹配路由；目标链路上的 handler 使用匹配后的 `params`（`context.request` 仍表示对外 URL）
-2. 执行该路径上的 handler 链直至得到 `Response`
-3. **不**默认重跑进入本次请求时已在全局层执行过的 middleware
+1. 将 `context.request` 设为 `new Request(resolvedDestination, context.request)`（同源校验与 query 合并见下文）
+2. 失效当前 route 激活状态（`module`、`meta`、`render`、`html`、`_handler` 等）
+3. 按新的 `context.request` **重新匹配尚未执行的 handler**，替换当前栈的剩余部分
+4. **不**重跑本请求中已执行过的全局 middleware（`*`）
 
-### 与 `next()` 的关系
+已在当前 handler 之前执行完毕的 middleware 不受影响；`return next()` 进入的是与新对内路径对应的下游栈。
 
-- 在**当前 handler** 内，`rewrite()` 与 `next()` 二选一：前者把「后续处理」委托给**另一条路径的链**，后者委托给**当前路径的下游**
-- `return ctx.rewrite(...)` 之后不应再对**当前栈**调用 `next()`
-- 已在 `await next()` 拿到 `Response` 之后再 `rewrite`：语义冲突，应拒绝
+### Route 激活
+
+不变量：**Context 上已激活的 route module 必须对应当前 `context.request` 的匹配结果。**
+
+- `rewrite()` 时：清除 route 衍生状态
+- 后续 handler 进入时：Engine 按当前 `context.request` match 到的 module 重新激活
+- `params`、`pathname`：随当前执行的 matched handler 更新（与直接访问目标路径一致）
+
+Rewrite 到 Route 时，应走与直接命中该 Route 相同的渲染与 layout 管道。
 
 ### Query
 
-遵循 `URL` 解析：`destination` 未带 search 时**保留**原请求 query；显式写在 `destination` 中的 query 优先。
+遵循 `URL` 解析：`destination` 未带 search 时**保留**当前 `context.request` 的 query；显式写在 `destination` 中的 query 优先。
 
 ### 错误、安全与缓存
 
 - 重写目标不存在或抛错：与直接访问该路径一致，走现有 404 / fallback
 - 仅允许同源或相对 `destination`
-- 缓存与 `Vary` 以**对外 URL** 为基准
-- 须限制 rewrite 深度并检测环
+- 缓存与 `Vary` 以 **`context.originalRequest`（对外 URL）** 为基准
+- 须限制 rewrite 深度并检测环（默认最大深度与错误形态由实现定义，建议 508）
 
-### SSR
+### 控制流对比
 
-Rewrite 到 Route 时，应走与直接命中该 Route 相同的渲染与 layout 管道。
+| 能力                   | 浏览器 URL | `context.request` | 返回值                           |
+| ---------------------- | ---------- | ----------------- | -------------------------------- |
+| `next()`               | 不变       | 不变              | 下游栈的 `Response`              |
+| `rewrite()` + `next()` | 不变       | 更新为对内路径    | 新栈的 `Response`（经 `next()`） |
+| `redirect()`           | 改变       | 不适用            | 3xx `Response`                   |
 
 ## 与现有能力的关系
 
-| 能力                         | 关系                                            |
-| ---------------------------- | ----------------------------------------------- |
-| `redirect()`                 | 改变客户端 URL；不重新匹配                      |
-| `proxy` / `fetchWithProxy`   | 对外 origin；与内部 rewrite 职责分离            |
-| `dispatch(new Request(...))` | 手工 workaround；实现后文档引导改用 `rewrite()` |
+| 能力                       | 关系                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------ |
+| `redirect()`               | 改变客户端 URL；不更新对内 `context.request`                                   |
+| `proxy` / `fetchWithProxy` | 对外 origin；与内部 rewrite 职责分离                                           |
+| 直接赋值 `context.request` | 不推荐；应使用 `context.rewrite()` 以集中同源校验、环检测、深度限制与 re-match |
 
-## 行业参考
+## 外部参考
 
-| 框架    | 做法                                                      |
-| ------- | --------------------------------------------------------- |
-| Next.js | `NextResponse.rewrite()`，返回 Response 形态，URL 栏不变  |
-| Astro   | `context.rewrite()`；可选 `originPathname` 表示改写前路径 |
-| 其它    | 多无一等 rewrite，或平台层 `fetch` 自建语义               |
+| 框架 / 生态 | 做法                                                                |
+| ----------- | ------------------------------------------------------------------- |
+| Koa         | `ctx.path` / `ctx.url` 可变；改路径后 `next()` 下游按新路径理解请求 |
+| Astro       | `context.rewrite()`；`originPathname` 表示改写前路径                |
+| Next.js     | `NextResponse.rewrite()`；内部路由与对外 URL 分离                   |
 
-共性：`return` 结束当前 middleware/handler；区分对外 URL 与对内路径；少暴露 rewrite 链或第二个 `Request`。
-
-## 待探讨
-
-1. **`destination` 是否接受 `Request`**（携带自定义 headers 的 internal 请求）
-2. **全局 middleware 在 rewrite 后是否允许 opt-in 重跑**
-3. **与 `ApplicationOptions.proxy` 的先后顺序**（对外 URL 与 forwarded 头的一致性）
-4. **默认最大 rewrite 深度与环检测策略**（数值与错误响应形态）
-5. **是否在后续版本公开 `originPathname`**（对标 Astro，对比 `ctx.state`）
+Web Router 的 rewrite 对齐 Koa 的**可变路由视图**模型，并扩展 **route module 激活**与 **剩余栈 re-match** 语义。
 
 ## 示例
+
+### Gateway middleware
 
 ```ts
 export const handler = defineMiddlewareHandler(async (ctx, next) => {
   const url = new URL(ctx.request.url);
   if (url.pathname.startsWith('/v1/')) {
-    const res = await ctx.rewrite(
-      new URL(url.pathname.replace(/^\/v1/, '/internal'), url)
-    );
+    ctx.rewrite(new URL(url.pathname.replace(/^\/v1/, '/internal'), url));
+    const res = await next();
     res.headers.set('x-routed-by', 'v1-gateway');
     return res;
   }
@@ -160,10 +189,26 @@ export const handler = defineMiddlewareHandler(async (ctx, next) => {
 });
 ```
 
-访问 `/v1/products/42` 时地址栏不变；响应体来自 `/internal/products/42` 的 Route，外层 middleware 仍可改写 headers 后返回。
+访问 `/v1/products/42` 时：
+
+- 浏览器地址栏仍为 `/v1/products/42`
+- `ctx.originalRequest.url` 为 `/v1/products/42`
+- `rewrite` 之后 `ctx.request.url` 对应 `/internal/products/42` 的对内路径
+- 响应体来自 `/internal/products/42` 的 Route；外层 middleware 仍可改写 headers
+
+### 读取对外 URL
+
+```ts
+export const handler = defineMiddlewareHandler(async (ctx, next) => {
+  const externalPath = new URL(ctx.originalRequest!.url).pathname;
+  ctx.state.externalPath = externalPath;
+  return next();
+});
+```
 
 ## 参考
 
-- [Next.js `NextResponse.rewrite`](https://nextjs.org/docs/app/api-reference/functions/next-response#rewrite)
+- [Koa Context](https://koajs.com/#context)
 - [Astro `context.rewrite` / `originPathname`](https://docs.astro.build/en/reference/api-reference/#rewrite)
+- [Next.js `NextResponse.rewrite`](https://nextjs.org/docs/app/api-reference/functions/next-response#rewrite)
 - 项目内：`docs/helpers/redirect.md`

--- a/rfcs/rewrite.zh.md
+++ b/rfcs/rewrite.zh.md
@@ -17,23 +17,11 @@ return next();
 
 ## 动机
 
-### 与 Redirect 的区别
+应用常需要**对外 URL 与对内路由分离**：浏览器地址栏保持 `/v1/products`，服务端改由 `/internal/products` 的 Route 处理（含 SSR）。这应在**同一次 HTTP 请求**内完成，而不是返回 3xx 让客户端重新请求——后者由已有的 `redirect()` 负责。
 
-|            | Rewrite                      | Redirect（已有 `redirect()`） |
-| ---------- | ---------------------------- | ----------------------------- |
-| 浏览器 URL | 不变                         | 变为 `Location` 目标          |
-| 对内路由   | 切换 `context.request`       | 不适用（客户端发起新请求）    |
-| 典型场景   | 门面路径、实验分流、渐进迁移 | 永久跳转、登录重定向          |
+`rewrite()` 填补的是框架级**内部路由切换**能力：在 middleware 中改写对内路径，并令后续 handler 栈按新路径继续执行。
 
-项目已有 `redirect()` 与对外 `proxy`，缺少**框架级内部路由重写**。自行 `dispatch(new Request(...))` 易导致 params、中间件顺序、route 激活与错误处理不一致。
-
-### 典型用例
-
-- 对外路径与对内路由解耦（如 `/v1/*` → `/internal/*`）
-- 结合 flags / cookie 分流到不同页面实现
-- 保留对外 URL 的审计与 SEO，对内走新 Route（含 SSR）
-
-### 非目标
+## 非目标
 
 - 声明式 rewrites 配置、构建期 routemap 改写
 - rewrite 到外部 origin（归 `@web-widget/helpers/proxy`）
@@ -42,7 +30,7 @@ return next();
 
 ## 核心抽象
 
-`context.rewrite(destination)` 的本质是**更新 Context 的对内路由视图**，语义上等价于：
+`context.rewrite(destination)` 的本质是更新 Context 的对内路由视图，语义上等价于：
 
 ```ts
 context.request = new Request(destination, context.request);
@@ -92,25 +80,25 @@ interface FetchContext {
 
 ### context.request 与 originalRequest
 
-| 字段                      | 含义                                                                                  |
-| ------------------------- | ------------------------------------------------------------------------------------- |
-| `context.request`         | 当前**对内路由**所用的 `Request`；`rewrite` 后更新为 `new Request(destination, prev)` |
-| `context.originalRequest` | 客户端原始 `Request`；整个请求生命周期内不变                                          |
+| 字段                      | 含义                                                                              |
+| ------------------------- | --------------------------------------------------------------------------------- |
+| `context.request`         | 当前对内路由所用的 `Request`；`rewrite` 后更新为 `new Request(destination, prev)` |
+| `context.originalRequest` | 客户端原始 `Request`；整个请求生命周期内不变                                      |
 
 需要对外 URL（鉴权、日志、canonical、SEO、缓存键）时，应读取 `context.originalRequest.url`（或其在 `context.state` 中的等价快照），而非假设 `context.request.url` 与地址栏一致。
 
 ### 与 next() 的关系
 
-| 能力        | 作用                                                             |
-| ----------- | ---------------------------------------------------------------- |
-| `rewrite()` | 切换对内 `Request`，失效 route 状态，**重新匹配剩余 handler 栈** |
-| `next()`    | 在（可能已更新的）栈上继续执行下游 handler                       |
+| 能力        | 作用                                                         |
+| ----------- | ------------------------------------------------------------ |
+| `rewrite()` | 切换对内 `Request`，失效 route 状态，重新匹配剩余 handler 栈 |
+| `next()`    | 在（可能已更新的）栈上继续执行下游 handler                   |
 
 规则：
 
-- **允许且推荐**：`context.rewrite(...); return next()`
-- **禁止**：`await next()` 完成后再 `rewrite()`（与 Koa 一致，语义冲突）
-- **禁止**：`rewrite()` 后在不 re-match 的情况下继续旧路径的 handler 栈（由实现保证）
+- 允许且推荐：`context.rewrite(...); return next()`
+- 禁止：`await next()` 完成后再 `rewrite()`（与 Koa 一致，语义冲突）
+- 禁止：`rewrite()` 后在不 re-match 的情况下继续旧路径的 handler 栈（由实现保证）
 
 `rewrite()` 不返回 `Response`。`Response` 由 `rewrite` 之后的新栈经 `next()` 产生，并可被外层 middleware 读取、修改后返回。
 
@@ -120,14 +108,14 @@ interface FetchContext {
 
 1. 将 `context.request` 设为 `new Request(resolvedDestination, context.request)`（同源校验与 query 合并见下文）
 2. 失效当前 route 激活状态（`module`、`meta`、`render`、`html`、`_handler` 等）
-3. 按新的 `context.request` **重新匹配尚未执行的 handler**，替换当前栈的剩余部分
-4. **不**重跑本请求中已执行过的全局 middleware（`*`）
+3. 按新的 `context.request` 重新匹配尚未执行的 handler，替换当前栈的剩余部分
+4. 不重跑本请求中已执行过的全局 middleware（`*`）
 
 已在当前 handler 之前执行完毕的 middleware 不受影响；`return next()` 进入的是与新对内路径对应的下游栈。
 
 ### Route 激活
 
-不变量：**Context 上已激活的 route module 必须对应当前 `context.request` 的匹配结果。**
+不变量：Context 上已激活的 route module 必须对应当前 `context.request` 的匹配结果。
 
 - `rewrite()` 时：清除 route 衍生状态
 - 后续 handler 进入时：Engine 按当前 `context.request` match 到的 module 重新激活
@@ -137,14 +125,29 @@ Rewrite 到 Route 时，应走与直接命中该 Route 相同的渲染与 layout
 
 ### Query
 
-遵循 `URL` 解析：`destination` 未带 search 时**保留**当前 `context.request` 的 query；显式写在 `destination` 中的 query 优先。
+遵循 `URL` 解析：`destination` 未带 search 时保留当前 `context.request` 的 query；显式写在 `destination` 中的 query 优先。
 
-### 错误、安全与缓存
+### 错误与安全
 
 - 重写目标不存在或抛错：与直接访问该路径一致，走现有 404 / fallback
 - 仅允许同源或相对 `destination`
-- 缓存与 `Vary` 以 **`context.originalRequest`（对外 URL）** 为基准
-- 须限制 rewrite 深度并检测环（默认最大深度与错误形态由实现定义，建议 508）
+- 须检测 rewrite 环：同一请求内不得 rewrite 到已访问过的 destination（pathname + search）；再次命中时拒绝（建议 508）
+
+### 缓存
+
+Rewrite 不改变浏览器地址栏 URL，但会切换对内 route。不同缓存层使用的键不同：
+
+**HTTP 共享缓存（CDN / 浏览器）**
+
+以 `context.originalRequest.url`（客户端可见 URL）为缓存键基准。边缘缓存与浏览器只感知对外请求；同一对外 URL 若总是 deterministic 地 rewrite 到同一对内路径，不必按对内路径再分桶。
+
+**应用内缓存 / 失效**
+
+以当前对内 route 路径（rewrite 后 `context.request` 的 match 结果）为基准。若框架提供按 path 失效的能力（类似 Next.js `revalidatePath`），应对 destination 路径操作，而非地址栏中的 source path。
+
+**Vary**
+
+遵循 HTTP 标准语义：`Vary` 声明哪些请求头会导致响应不同，而非 URL 本身。框架不因 rewrite 自动添加 URL 相关 `Vary`。需要按对外 URL 或自定义维度区分响应时，由 route 或 middleware 自行设置 `Cache-Control` / `Vary`。
 
 ### 控制流对比
 
@@ -156,11 +159,11 @@ Rewrite 到 Route 时，应走与直接命中该 Route 相同的渲染与 layout
 
 ## 与现有能力的关系
 
-| 能力                       | 关系                                                                           |
-| -------------------------- | ------------------------------------------------------------------------------ |
-| `redirect()`               | 改变客户端 URL；不更新对内 `context.request`                                   |
-| `proxy` / `fetchWithProxy` | 对外 origin；与内部 rewrite 职责分离                                           |
-| 直接赋值 `context.request` | 不推荐；应使用 `context.rewrite()` 以集中同源校验、环检测、深度限制与 re-match |
+| 能力                       | 关系                                                                 |
+| -------------------------- | -------------------------------------------------------------------- |
+| `redirect()`               | 改变客户端 URL；不更新对内 `context.request`                         |
+| `proxy` / `fetchWithProxy` | 对外 origin；与内部 rewrite 职责分离                                 |
+| 直接赋值 `context.request` | 不推荐；应使用 `context.rewrite()` 以集中同源校验、环检测与 re-match |
 
 ## 外部参考
 
@@ -170,7 +173,7 @@ Rewrite 到 Route 时，应走与直接命中该 Route 相同的渲染与 layout
 | Astro       | `context.rewrite()`；`originPathname` 表示改写前路径                |
 | Next.js     | `NextResponse.rewrite()`；内部路由与对外 URL 分离                   |
 
-Web Router 的 rewrite 对齐 Koa 的**可变路由视图**模型，并扩展 **route module 激活**与 **剩余栈 re-match** 语义。
+Web Router 的 rewrite 对齐 Koa 的可变路由视图模型，并扩展 route module 激活与剩余栈 re-match 语义。
 
 ## 示例
 


### PR DESCRIPTION
## Summary

- Revise `rfcs/rewrite.zh.md` to define rewrite as updating the internal routing view (`context.request = new Request(destination, prev)`) rather than returning a target-chain `Response`.
- Document the recommended pattern `rewrite(...); return next()`, route module invalidation/re-activation, remaining-stack re-match, and one-shot global middleware semantics.
- Add `context.originalRequest` as the future-facing API for the client URL; cache and canonical should use it instead of assuming `context.request` matches the address bar.

## Test plan

- [x] RFC prose review only (no implementation changes in this PR)