### PR TITLE
fix(web-router): defer route activation clear until waitUntil completes

### DIFF
--- a/.changeset/waituntil-route-activation.md
+++ b/.changeset/waituntil-route-activation.md
@@ -1,0 +1,7 @@
+---
+'@web-widget/web-router': patch
+---
+
+Defer route activation cleanup until `waitUntil` background tasks finish, so stale-while-revalidate revalidation keeps `context.meta` available when the origin handler runs.
+
+Fixes #771.

--- a/packages/middlewares/src/cache.test.ts
+++ b/packages/middlewares/src/cache.test.ts
@@ -413,6 +413,77 @@ test('it should be possible to terminate cache revalidate', async () => {
   expect(await res.text()).toBe('View: 0');
 });
 
+test('waitUntil revalidate keeps context.meta during stale-while-revalidate', async () => {
+  let generation = 0;
+  let revalidateMetaAvailable: boolean | undefined;
+  const caches = createCaches();
+  const app = WebRouter.fromManifest({
+    routes: [
+      {
+        pathname: '*',
+        module: {
+          render: () => 'Page',
+          handler: {
+            GET(context) {
+              const hadMeta = context.meta != null;
+              // Same failure mode as mergeMeta(context.meta, …) when meta is cleared.
+              Object.entries(context.meta!);
+              if (generation > 0) {
+                revalidateMetaAvailable = hadMeta;
+              }
+              return new Response(`Gen ${generation++}`);
+            },
+          },
+        },
+      },
+    ],
+    middlewares: [
+      {
+        pathname: '*',
+        module: {
+          handler: cache({
+            cacheControl: {
+              sharedMaxAge: 1,
+              staleWhileRevalidate: 5,
+            },
+            caches,
+          }),
+        },
+      },
+    ],
+  });
+
+  const waitUntilTasks: Promise<unknown>[] = [];
+  const executionContext = {
+    waitUntil: (promise: Promise<unknown>) => {
+      waitUntilTasks.push(promise);
+    },
+    passThroughOnException: () => {},
+  };
+
+  let res = await app.dispatch(
+    TEST_URL,
+    undefined,
+    undefined,
+    executionContext
+  );
+  expect(res.status).toBe(200);
+  expect(res.headers.get('x-cache-status')).toBe(MISS);
+  expect(await res.text()).toBe('Gen 0');
+  expect(revalidateMetaAvailable).toBeUndefined();
+
+  await timeout(1024);
+
+  res = await app.dispatch(TEST_URL, undefined, undefined, executionContext);
+  expect(res.status).toBe(200);
+  expect(res.headers.get('x-cache-status')).toBe(STALE);
+  expect(await res.text()).toBe('Gen 0');
+
+  await Promise.allSettled(waitUntilTasks);
+  expect(revalidateMetaAvailable).toBe(true);
+  expect(generation).toBe(2);
+});
+
 describe('cache middleware error boundaries', () => {
   let consoleErrorSpy: ReturnType<typeof jest.spyOn>;
 

--- a/packages/web-router/src/application.ts
+++ b/packages/web-router/src/application.ts
@@ -440,9 +440,27 @@ class Application<
           )
         );
       } finally {
-        this.#moduleRuntime?.clearActivation(context);
+        this.#releaseRouteActivation(context);
       }
     })();
+  }
+
+  /** Clears route activation after dispatch; defers until `waitUntil` tasks finish. */
+  #releaseRouteActivation(context: Context<E>): void {
+    const runtime = this.#moduleRuntime;
+    if (!runtime) {
+      return;
+    }
+
+    const pending = context.getPendingBackgroundTasks();
+    if (pending.length > 0) {
+      void Promise.allSettled(pending).finally(() => {
+        runtime.clearActivation(context);
+      });
+      return;
+    }
+
+    runtime.clearActivation(context);
   }
 
   /**

--- a/packages/web-router/src/context.test.ts
+++ b/packages/web-router/src/context.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'vitest';
+import { Context } from './context';
+
+describe('Context.waitUntil', () => {
+  test('delegates promises to executionContext', () => {
+    const delegated: Promise<unknown>[] = [];
+    const context = new Context(new Request('http://localhost/'), {
+      env: {},
+      executionContext: {
+        waitUntil: (promise) => {
+          delegated.push(promise);
+        },
+        passThroughOnException: () => {},
+      },
+    });
+
+    const task = Promise.resolve('done');
+    context.waitUntil(task);
+
+    expect(delegated).toEqual([task]);
+  });
+
+  test('tracks pending tasks until they settle', async () => {
+    let resolveTask!: () => void;
+    const task = new Promise<void>((resolve) => {
+      resolveTask = resolve;
+    });
+    const context = new Context(new Request('http://localhost/'), {
+      env: {},
+      executionContext: {
+        waitUntil: () => {},
+        passThroughOnException: () => {},
+      },
+    });
+
+    context.waitUntil(task);
+    expect(context.getPendingBackgroundTasks()).toHaveLength(1);
+
+    resolveTask();
+    await task;
+    expect(context.getPendingBackgroundTasks()).toHaveLength(0);
+  });
+
+  test('tracks multiple concurrent waitUntil tasks', async () => {
+    const context = new Context(new Request('http://localhost/'), {
+      env: {},
+      executionContext: {
+        waitUntil: () => {},
+        passThroughOnException: () => {},
+      },
+    });
+
+    let resolveFirst!: () => void;
+    let resolveSecond!: () => void;
+    const first = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const second = new Promise<void>((resolve) => {
+      resolveSecond = resolve;
+    });
+
+    context.waitUntil(first);
+    context.waitUntil(second);
+    expect(context.getPendingBackgroundTasks()).toHaveLength(2);
+
+    resolveFirst();
+    await first;
+    expect(context.getPendingBackgroundTasks()).toHaveLength(1);
+
+    resolveSecond();
+    await second;
+    expect(context.getPendingBackgroundTasks()).toHaveLength(0);
+  });
+
+  test('throws when executionContext is missing', () => {
+    const context = new Context(new Request('http://localhost/'), { env: {} });
+    expect(() => context.waitUntil(Promise.resolve())).toThrow(/FetchEvent/);
+  });
+});

--- a/packages/web-router/src/context.ts
+++ b/packages/web-router/src/context.ts
@@ -25,6 +25,7 @@ export class Context<E extends Env = Env> implements FetchContext {
   readonly originalRequest: Request;
   #waitUntil?: FetchContext['waitUntil'];
   #executionContext?: ExecutionContext;
+  #pendingBackgroundTasks = new Set<Promise<unknown>>();
 
   /** Bound per request in Application.handler. */
   rewrite!: FetchContext['rewrite'];
@@ -52,11 +53,23 @@ export class Context<E extends Env = Env> implements FetchContext {
     if (this.#waitUntil) {
       return this.#waitUntil;
     } else if (this.#executionContext) {
-      return (this.#waitUntil = this.#executionContext.waitUntil.bind(
+      const delegate = this.#executionContext.waitUntil.bind(
         this.#executionContext
-      ));
+      );
+      return (this.#waitUntil = (promise: Promise<unknown>) => {
+        const tracked = Promise.resolve(promise).finally(() => {
+          this.#pendingBackgroundTasks.delete(tracked);
+        });
+        this.#pendingBackgroundTasks.add(tracked);
+        delegate(promise);
+      });
     } else {
       throw new Error('This context has no FetchEvent.');
     }
+  }
+
+  /** @internal Pending promises registered via {@link waitUntil}. */
+  getPendingBackgroundTasks(): readonly Promise<unknown>[] {
+    return [...this.#pendingBackgroundTasks];
   }
 }

--- a/packages/web-router/src/index.test.ts
+++ b/packages/web-router/src/index.test.ts
@@ -366,6 +366,70 @@ describe('background tasks', () => {
   });
 });
 
+describe('waitUntil route activation', () => {
+  test('background next() keeps context.meta after stale response (web-widget#771)', async () => {
+    let metaDuringBackground: unknown;
+    let handlerInvoked = false;
+    const waitUntilTasks: Promise<unknown>[] = [];
+
+    const app = WebRouter.fromManifest({
+      routes: [
+        {
+          pathname: '/page',
+          module: {
+            render: () => 'Page',
+            meta: { title: 'Page' },
+            handler: {
+              GET(c: RouteContext) {
+                handlerInvoked = true;
+                metaDuringBackground = c.meta;
+                Object.entries(c.meta!);
+                return new Response('origin');
+              },
+            },
+          },
+        },
+      ],
+      middlewares: [
+        {
+          pathname: '/page',
+          module: {
+            handler: async (c, next) => {
+              c.waitUntil(
+                (async () => {
+                  await new Promise((resolve) => setTimeout(resolve, 50));
+                  await next();
+                })()
+              );
+              return new Response('stale');
+            },
+          },
+        },
+      ],
+    });
+
+    const res = await app.dispatch(
+      'http://localhost/page',
+      undefined,
+      undefined,
+      {
+        waitUntil: (promise) => {
+          waitUntilTasks.push(promise);
+        },
+        passThroughOnException: () => {},
+      }
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('stale');
+    expect(handlerInvoked).toBe(false);
+
+    await Promise.allSettled(waitUntilTasks);
+    expect(handlerInvoked).toBe(true);
+    expect(metaDuringBackground).toBeDefined();
+    expect(metaDuringBackground).toMatchObject({ title: 'Page' });
+  });
+});
+
 describe('html method', () => {
   test('html should work with simple data', async () => {
     const testData = { message: 'Hello, World!' };


### PR DESCRIPTION
## Summary

- Track promises registered via `context.waitUntil()` and defer `clearActivation` until they settle, so stale-while-revalidate background revalidation keeps `context.meta` available when the origin handler runs.
- Add regression tests for `waitUntil` tracking, SWR-style background `next()`, and cache middleware revalidation.

Fixes #771

## Test plan

- [x] `pnpm exec vitest run src/context.test.ts src/index.test.ts -t "waitUntil"` in `packages/web-router`
- [x] `pnpm test -- src/cache.test.ts -t "waitUntil revalidate"` in `packages/middlewares`