### PR TITLE
feat(middlewares): adopt shared-cache createCacheHandler

### DIFF
--- a/.changeset/middleware-shared-cache-handler.md
+++ b/.changeset/middleware-shared-cache-handler.md
@@ -1,0 +1,6 @@
+---
+'@web-widget/middlewares': minor
+'@web-widget/web-router': patch
+---
+
+Upgrade to `@web-widget/shared-cache` 2.x and adopt `createCacheHandler` for cache middleware origin resolution. Server errors during cache miss propagate to the router error handler; errors during background revalidation return 5xx responses. Remove the `x-transform-error` workaround from web-router.

--- a/packages/middlewares/package.json
+++ b/packages/middlewares/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@web-widget/helpers": "workspace:*",
     "@web-widget/schema": "workspace:*",
-    "@web-widget/shared-cache": "^1.8.0"
+    "@web-widget/shared-cache": "^2.1.0"
   },
   "devDependencies": {
     "@jest/globals": "catalog:",

--- a/packages/middlewares/src/cache.test.ts
+++ b/packages/middlewares/src/cache.test.ts
@@ -2,10 +2,7 @@ import { afterEach, beforeEach, jest } from '@jest/globals';
 import { LRUCache } from 'lru-cache';
 import type { Manifest } from '@web-widget/web-router';
 import WebRouter from '@web-widget/web-router';
-import type {
-  KVStorage,
-  SharedCacheStatus as CacheStatus,
-} from '@web-widget/shared-cache';
+import type { KVStorage, CacheStatus } from '@web-widget/shared-cache';
 import { CacheStorage } from '@web-widget/shared-cache';
 import conditional from './conditional-get';
 import type { CacheOptions } from './cache';
@@ -15,7 +12,7 @@ const HIT: CacheStatus = 'HIT';
 const MISS: CacheStatus = 'MISS';
 const EXPIRED: CacheStatus = 'EXPIRED';
 const BYPASS: CacheStatus = 'BYPASS';
-const STALE: CacheStatus = 'STALE';
+const UPDATING: CacheStatus = 'UPDATING';
 const DYNAMIC: CacheStatus = 'DYNAMIC';
 const TEST_URL = 'http://localhost/';
 
@@ -194,7 +191,7 @@ describe('debug cache key header', () => {
     });
     const res = await app.dispatch(TEST_URL);
 
-    expect(res.headers.get('x-cache-key')).toBe('localhost/');
+    expect(res.headers.get('x-cache-key')).toBe('http://localhost/');
   });
 
   test('should apply vary to debug cache key', async () => {
@@ -209,7 +206,7 @@ describe('debug cache key header', () => {
     });
 
     expect(res.headers.get('x-cache-key')).toMatch(
-      /^localhost\/:accept-language=[a-f0-9]+$/
+      /^http:\/\/localhost\/\|v\|accept-language@[a-f0-9]+$/
     );
   });
 });
@@ -409,7 +406,9 @@ test('it should be possible to terminate cache revalidate', async () => {
     },
   });
   expect(res.status).toBe(200);
-  expect(res.headers.get('x-cache-status')).toBe(STALE);
+  // NOTE: With stale-while-revalidate enabled, the foreground response is served
+  // immediately as UPDATING while revalidation runs in the background.
+  expect(res.headers.get('x-cache-status')).toBe(UPDATING);
   expect(await res.text()).toBe('View: 0');
 });
 
@@ -476,7 +475,8 @@ test('waitUntil revalidate keeps context.meta during stale-while-revalidate', as
 
   res = await app.dispatch(TEST_URL, undefined, undefined, executionContext);
   expect(res.status).toBe(200);
-  expect(res.headers.get('x-cache-status')).toBe(STALE);
+  // NOTE: Foreground stale-while-revalidate serves cached content as UPDATING.
+  expect(res.headers.get('x-cache-status')).toBe(UPDATING);
   expect(await res.text()).toBe('Gen 0');
 
   await Promise.allSettled(waitUntilTasks);
@@ -549,29 +549,23 @@ describe('cache middleware error boundaries', () => {
     expect(body).toMatch(/sync route error|Internal Server Error|Error/i);
   });
 
-  test('when Response.json fails, error handling falls back to plain text with x-transform-error', async () => {
-    const jsonSpy = jest.spyOn(Response, 'json').mockImplementation(() => {
-      throw new Error('Response.json unavailable');
-    });
-
-    try {
-      const app = createApp(createCaches(), { cacheControl: { maxAge: 10 } }, [
-        {
-          pathname: '*',
-          module: {
-            handler: async () => {
-              throw new Error('original route error');
-            },
+  test('when route throws, error propagates through framework error handling', async () => {
+    const app = createApp(createCaches(), { cacheControl: { maxAge: 10 } }, [
+      {
+        pathname: '*',
+        module: {
+          handler: async () => {
+            throw new Error('original route error');
           },
         },
-      ]);
-      const res = await app.dispatch(TEST_URL);
+      },
+    ]);
+    const res = await app.dispatch(TEST_URL);
 
-      expect(res.headers.get('x-transform-error')).toBe('true');
-      expect(res.headers.get('content-type')).toContain('text/plain');
-    } finally {
-      jsonSpy.mockRestore();
-    }
+    expect(res.status).toBe(500);
+    // NOTE: Miss-phase throws now reach Web Router fallback instead of being
+    // converted to synthetic JSON error responses inside the cache middleware.
+    expect(res.headers.get('content-type')).toContain('text/html');
   });
 
   test('when reading error fields throws, error handling falls back to plain text', async () => {
@@ -595,7 +589,6 @@ describe('cache middleware error boundaries', () => {
     const res = await app.dispatch(TEST_URL);
 
     expect(res.status).toBe(500);
-    expect(res.headers.get('x-transform-error')).toBe('true');
     expect(res.headers.get('content-type')).toContain('text/plain');
   });
 

--- a/packages/middlewares/src/cache.ts
+++ b/packages/middlewares/src/cache.ts
@@ -1,15 +1,15 @@
-import type { MiddlewareNext, RouteConfig } from '@web-widget/helpers';
+import type { RouteConfig } from '@web-widget/helpers';
 import { defineMiddlewareHandler } from '@web-widget/helpers';
 import {
   stringifyResponseCacheControl,
   type ResponseCacheControl,
 } from '@web-widget/helpers/headers';
-import { createFetch } from '@web-widget/shared-cache';
+import { createCacheHandler } from '@web-widget/shared-cache';
 import type {
-  Cache,
+  CacheOriginContext,
   CacheStorage,
-  SharedCacheKeyRules as CacheKeyRules,
-  SharedCacheStatus as CacheStatus,
+  CacheKeyRules,
+  CacheStatus,
 } from '@web-widget/shared-cache';
 
 declare module '@web-widget/schema' {
@@ -143,21 +143,28 @@ export default function cache(options?: CacheOptions) {
     const signal =
       typeof signalOption === 'function' ? signalOption() : signalOption;
     const cache = await caches.open(cacheName);
-    const fetch = nextToFetch(cache, next);
     const waitUntil = context.waitUntil.bind(context);
 
-    return fetch(request, {
-      sharedCache: {
-        cacheControlOverride: cacheControl,
-        cacheKeyRules,
-        debugCacheKey,
-        ignoreRequestCacheControl,
-        ignoreVary,
-        varyOverride: vary,
+    // NOTE: Use middleware-friendly cache resolution instead of wrapping `next()` in
+    // `createFetch`. On cache miss, origin throws propagate to the framework `onError`
+    // handler. Revalidation failures are converted to 5xx inside shared-cache for
+    // `stale-if-error` / `stale-while-revalidate` semantics.
+    return createCacheHandler(cache, {
+      cacheControlOverride: cacheControl,
+      cacheKeyRules,
+      debugCacheKey,
+      ignoreRequestCacheControl,
+      ignoreVary,
+      varyOverride: vary,
+    }).resolve(
+      request,
+      // The origin request from shared-cache is ignored; `next()` uses middleware context.
+      (_req: Request, _ctx: CacheOriginContext) => next(),
+      {
         waitUntil,
-      },
-      signal,
-    });
+        signal,
+      }
+    );
   });
 }
 
@@ -173,101 +180,4 @@ async function getRouteCacheConfig(
 
 function setCacheStatus(headers: Headers, status: CacheStatus) {
   headers.set('x-cache-status', status);
-}
-
-function errorToResponse(error: any = {}): Response {
-  const errorHeaders = {
-    // NOTE: Web Router supports this custom header to transform error responses
-    'x-transform-error': 'true',
-  } as const;
-
-  try {
-    const status =
-      typeof error?.status === 'number'
-        ? error.status
-        : error?.name === 'TimeoutError'
-          ? 504
-          : 500;
-    const statusText = error?.statusText ?? error?.name ?? '';
-    return Response.json(
-      {
-        name: error?.name,
-        message: error?.message,
-        stack: error?.stack,
-      },
-      {
-        status,
-        statusText,
-        headers: errorHeaders,
-      }
-    );
-  } catch {
-    return new Response('Internal Server Error', {
-      status: 500,
-      statusText: 'Internal Server Error',
-      headers: {
-        ...errorHeaders,
-        'content-type': 'text/plain; charset=utf-8',
-      },
-    });
-  }
-}
-
-function nextToFetch(cache: Cache, next: MiddlewareNext) {
-  return createFetch(cache, {
-    fetch: async (input, init) => {
-      const request = new Request(input, init);
-
-      if (!request.signal) {
-        try {
-          return await next();
-        } catch (error) {
-          return errorToResponse(error);
-        }
-      }
-
-      const signal = request.signal;
-      let isAborted = signal.aborted;
-
-      if (isAborted) {
-        return errorToResponse(signal.reason);
-      }
-
-      return new Promise((resolve) => {
-        const onAbort = () => {
-          isAborted = true;
-          resolve(errorToResponse(signal.reason));
-        };
-
-        let response;
-
-        try {
-          response = next();
-        } catch (error) {
-          resolve(errorToResponse(error));
-        }
-
-        if (response instanceof Promise) {
-          response
-            .then(
-              (response) => {
-                signal.removeEventListener('abort', onAbort);
-                if (isAborted) return;
-                resolve(response);
-              },
-              (error) => {
-                signal.removeEventListener('abort', onAbort);
-                resolve(errorToResponse(error));
-              }
-            )
-            .catch((error) => {
-              signal.removeEventListener('abort', onAbort);
-              resolve(errorToResponse(error));
-            });
-        }
-
-        signal.addEventListener('abort', onAbort);
-      });
-    },
-  });
 }

--- a/packages/web-router/src/application.test.ts
+++ b/packages/web-router/src/application.test.ts
@@ -727,16 +727,13 @@ describe('error handle', () => {
     });
 
     app.use('/error-response', async () => {
-      return Response.json(
+      throw Response.json(
         {
           name: 'Error',
           message: 'This is Response Error',
         },
         {
           status: 500,
-          headers: {
-            'x-transform-error': 'true',
-          },
         }
       );
     });

--- a/packages/web-router/src/application.ts
+++ b/packages/web-router/src/application.ts
@@ -414,16 +414,9 @@ class Application<
       try {
         const res = await this.#dispatchMatched(context, path, frame);
 
-        if (
-          res.status >= 400 &&
-          // NOTE: This is a workaround to handle the error response from the cache middleware.
-          // https://github.com/web-widget/web-widget/blob/6ed821db5535aa274f1ee151fff38f1ea0a99231/packages/middlewares/src/cache.ts#L189
-          // TODO: This is not a good code, we will eliminate it later.
-          res.headers.has('x-transform-error') &&
-          res.headers.get('content-type') === 'application/json'
-        ) {
-          throw res;
-        }
+        // NOTE: Cache middleware uses `createCacheHandler`, which propagates origin
+        // throws on cache miss to this catch block. The former `x-transform-error`
+        // response round-trip is no longer needed.
 
         return finalizeHeadResponse(originalRequest, res);
       } catch (error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,7 +450,7 @@ importers:
         version: 4.20250409.0
       ts-jest:
         specifier: 'catalog:'
-        version: 29.2.1(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.27.3)(jest@29.7.0(@types/node@22.2.0)(ts-node@10.9.2(@types/node@22.2.0)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.1(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest@29.7.0(@types/node@22.2.0)(ts-node@10.9.2(@types/node@22.2.0)(typescript@5.5.4)))(typescript@5.5.4)
       tsup:
         specifier: 'catalog:'
         version: 8.3.4(jiti@2.4.2)(postcss@8.5.14)(typescript@5.5.4)
@@ -634,8 +634,8 @@ importers:
         specifier: workspace:*
         version: link:../schema
       '@web-widget/shared-cache':
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^2.1.0
+        version: 2.1.0
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -660,7 +660,7 @@ importers:
         version: 4.20250409.0
       ts-jest:
         specifier: 'catalog:'
-        version: 29.2.1(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(esbuild@0.24.0)(jest@29.7.0(@types/node@22.2.0)(ts-node@10.9.2(@types/node@22.2.0)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.1(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.27.3)(jest@29.7.0(@types/node@22.2.0)(ts-node@10.9.2(@types/node@22.2.0)(typescript@5.5.4)))(typescript@5.5.4)
       tsup:
         specifier: 'catalog:'
         version: 8.3.4(jiti@2.4.2)(postcss@8.5.14)(typescript@5.5.4)
@@ -3388,11 +3388,11 @@ packages:
       react-dom:
         optional: true
 
-  '@web-widget/http-cache-semantics@1.2.0':
-    resolution: {integrity: sha512-q/MobtHmwp3oaHmEATX/f6BJ+4bNMPVQ1nfDiNW9GkGI/JxRGhpOcs8wxdyr4tbcTgkuqjex8h9G7ONTDuVBmQ==}
+  '@web-widget/http-cache-semantics@2.0.1':
+    resolution: {integrity: sha512-JKJygfnKVCz+qsLgdGa9qOo1B9W+NpNK/RsdXPmiESsazSceMPwwLTkmP4Ni0UFfcDILnEVo9BFV2XejMgN7jA==}
 
-  '@web-widget/shared-cache@1.8.0':
-    resolution: {integrity: sha512-KrvrVaA2lmAPHC5pvPBzXmcWo/SnTvsEqjzi4TbSVkL0V2BB/GAGxzvxATU4sGD1T0IakemhIHM0d/LpZt6VBg==}
+  '@web-widget/shared-cache@2.1.0':
+    resolution: {integrity: sha512-Ud/PBbgvLU0ymhQ5NKFmrWCvUuNS830D1KyBLc72Om+zttgVg85khfudGjHQANentL6bST+oC6BXHn1R1l/oLQ==}
 
   '@web/browser-logs@0.4.0':
     resolution: {integrity: sha512-/EBiDAUCJ2DzZhaFxTPRIznEPeafdLbXShIL6aTu7x73x7ZoxSDv7DGuTsh2rWNMUa4+AKli4UORrpyv6QBOiA==}
@@ -10306,12 +10306,12 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@web-widget/http-cache-semantics@1.2.0': {}
+  '@web-widget/http-cache-semantics@2.0.1': {}
 
-  '@web-widget/shared-cache@1.8.0':
+  '@web-widget/shared-cache@2.1.0':
     dependencies:
       '@edge-runtime/cookies': 6.0.0
-      '@web-widget/http-cache-semantics': 1.2.0
+      '@web-widget/http-cache-semantics': 2.0.1
 
   '@web/browser-logs@0.4.0':
     dependencies:
@@ -15279,7 +15279,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.2.1(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(esbuild@0.24.0)(jest@29.7.0(@types/node@22.2.0)(ts-node@10.9.2(@types/node@22.2.0)(typescript@5.5.4)))(typescript@5.5.4):
+  ts-jest@29.2.1(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest@29.7.0(@types/node@22.2.0)(ts-node@10.9.2(@types/node@22.2.0)(typescript@5.5.4)))(typescript@5.5.4):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -15297,7 +15297,6 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.28.0)
-      esbuild: 0.24.0
 
   ts-jest@29.2.1(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.27.3)(jest@29.7.0(@types/node@22.2.0)(ts-node@10.9.2(@types/node@22.2.0)(typescript@5.5.4)))(typescript@5.5.4):
     dependencies:


### PR DESCRIPTION
## Summary

- Upgrade `@web-widget/shared-cache` to **2.1.0** and migrate cache middleware to `createCacheHandler` for phase-aware origin resolution (miss throws to router `onError`; revalidation returns 5xx).
- Remove the `x-transform-error` workaround from `@web-widget/web-router` — errors no longer need to be smuggled through synthetic Response headers.
- Update cache middleware tests for shared-cache 2.x types (`CacheStatus`, `CacheKeyRules`) and cache key format.

Depends on [shared-cache#72](https://github.com/web-widget/shared-cache/pull/72) (`@web-widget/shared-cache@2.1.0`).

## Test plan

- [x] `pnpm --filter @web-widget/middlewares test` — 37 tests pass
- [x] `pnpm --filter @web-widget/middlewares exec tsc --noEmit`
- [ ] CI green on PR