### PR TITLE
fix(node,vite-plugin): fix HTTP/2 HEAD requests returning 404

### DIFF
--- a/.changeset/fix-http2-head-response.md
+++ b/.changeset/fix-http2-head-response.md
@@ -1,0 +1,11 @@
+---
+'@web-widget/node': patch
+'@web-widget/vite-plugin': patch
+---
+
+Fix HTTP/2 HEAD request handling in Node adapter and Vite dev middleware.
+
+- Detect Http2ServerResponse via `stream` when `httpVersionMajor` is missing
+- Skip writing `statusMessage` on HTTP/2 responses
+- Avoid calling Connect `next()` after the response has already been sent
+- Skip `transformIndexHtml` for HEAD requests in dev middleware

--- a/packages/node/src/adapter.ts
+++ b/packages/node/src/adapter.ts
@@ -83,6 +83,24 @@ function addDuplexToInit(init: RequestInit | undefined) {
   return init;
 }
 
+function isHttp2ServerResponse(serverResponse: ServerResponse): boolean {
+  // Http2ServerResponse exposes `stream` but may omit httpVersionMajor on Node 20.
+  if ('stream' in serverResponse && serverResponse.stream) return true;
+  const httpVersionMajor = (
+    serverResponse as ServerResponse & { httpVersionMajor?: number }
+  ).httpVersionMajor;
+  return Number(httpVersionMajor) >= 2;
+}
+
+function setHttp1StatusMessage(
+  serverResponse: ServerResponse,
+  statusMessage: string
+) {
+  if (!isHttp2ServerResponse(serverResponse) && statusMessage) {
+    serverResponse.statusMessage = statusMessage;
+  }
+}
+
 function toMiddleware(
   webHandler: WebHandler,
   options: RequestOptions
@@ -96,13 +114,15 @@ function toMiddleware(
       const event = toFetchEvent(request);
       const webResponse = await webHandler(request, env, event);
       await toServerResponse(webResponse, serverResponse);
-      await next();
+      if (!serverResponse.headersSent && !serverResponse.writableEnded) {
+        await next();
+      }
     } catch (error: unknown) {
       let responded = false;
       if (checkWritable(serverResponse) && !serverResponse.headersSent) {
         try {
           serverResponse.statusCode = 500;
-          serverResponse.statusMessage = 'Internal Server Error';
+          setHttp1StatusMessage(serverResponse, 'Internal Server Error');
           serverResponse.setHeader('content-type', 'text/plain; charset=utf-8');
           serverResponse.end(
             error instanceof Error ? error.message : 'Internal Server Error'
@@ -134,15 +154,21 @@ async function toServerResponse(
     return;
   }
 
+  const isHttp2 = isHttp2ServerResponse(serverResponse);
+  const headers = toOutgoingHeaders(webResponse.headers);
+  const status = webResponse.status;
+
   if (!serverResponse.headersSent) {
-    mergeIntoServerResponse(
-      toOutgoingHeaders(webResponse.headers),
-      serverResponse
-    );
+    mergeIntoServerResponse(headers, serverResponse);
+    serverResponse.statusCode = status;
+    if (!isHttp2) {
+      setHttp1StatusMessage(serverResponse, webResponse.statusText);
+    }
+  } else if (!isHttp2) {
+    serverResponse.statusCode = status;
+    setHttp1StatusMessage(serverResponse, webResponse.statusText);
   }
 
-  serverResponse.statusCode = webResponse.status;
-  serverResponse.statusMessage = webResponse.statusText;
   if (!webResponse.body) {
     serverResponse.end();
     return;
@@ -192,6 +218,9 @@ function checkWritable(serverResponse: ServerResponse) {
   // https://stackoverflow.com/questions/16254385/undocumented-response-finished-in-node-js
   if (serverResponse.writableEnded || serverResponse.finished) return false;
 
+  // Http2ServerResponse may omit httpVersionMajor and report socket.writable=false.
+  if ('stream' in serverResponse && serverResponse.stream) return true;
+
   const socket = serverResponse.socket;
   // There are already pending outgoing res, but still writable
   // https://github.com/nodejs/node/blob/v4.4.7/lib/_http_server.js#L486
@@ -220,7 +249,7 @@ function buildToNodeHandler(
           .catch(() => {
             if (checkWritable(serverResponse) && !serverResponse.headersSent) {
               serverResponse.statusCode = 500;
-              serverResponse.statusMessage = 'Internal Server Error';
+              setHttp1StatusMessage(serverResponse, 'Internal Server Error');
               serverResponse.setHeader(
                 'content-type',
                 'text/plain; charset=utf-8'
@@ -232,7 +261,7 @@ function buildToNodeHandler(
         toServerResponse(maybePromise, serverResponse).catch(() => {
           if (checkWritable(serverResponse) && !serverResponse.headersSent) {
             serverResponse.statusCode = 500;
-            serverResponse.statusMessage = 'Internal Server Error';
+            setHttp1StatusMessage(serverResponse, 'Internal Server Error');
             serverResponse.setHeader(
               'content-type',
               'text/plain; charset=utf-8'

--- a/packages/vite-plugin/src/dev/index.ts
+++ b/packages/vite-plugin/src/dev/index.ts
@@ -159,6 +159,9 @@ async function viteWebRouterMiddlewareV2(
       async handler(request, ...args) {
         try {
           let res = await webRouter.handler(request, ...args);
+          if (request.method === 'HEAD') {
+            return res;
+          }
           const contentType = res.headers.get('content-type') || '';
           const isHtml = contentType.includes('text/html');
           const isJSON = request.url.endsWith('.json');


### PR DESCRIPTION
## Summary

Fixes `HEAD /` returning 404 when Vite dev HTTPS uses `http2.createSecureServer`.

- **`@web-widget/node`**: On Node 20, `Http2ServerResponse` may have `httpVersionMajor` as `undefined` and `socket.writable === false`, causing `checkWritable()` to fail, the response to never be sent, and Connect `finalhandler` to return 404.
- **`@web-widget/vite-plugin`**: Skips `transformIndexHtml` for HEAD requests in dev middleware, preserving the body-less response that web-router already finalized.

## Changes

### `@web-widget/node`
- Add `isHttp2ServerResponse()` to detect HTTP/2 via `serverResponse.stream`
- Treat HTTP/2 streams as writable in `checkWritable()`
- Do not set `statusMessage` on HTTP/2 responses (avoids `UnsupportedWarning`)
- Do not call Connect `next()` after the response has already been sent

### `@web-widget/vite-plugin`
- Return early for HEAD requests in `viteWebRouterMiddlewareV2` before HTML transformation

## Test plan

- [ ] `pnpm --filter @web-widget/node run build`
- [ ] `pnpm --filter @web-widget/vite-plugin run build`
- [ ] Verify on Vite HTTPS dev server:
  ```bash
  curl -sk --http2 -I https://localhost:5173/
  # Expect HTTP/2 200, not finalhandler 404 (default-src 'none')
  curl -sk --http1.1 -I https://localhost:5173/
  # Expect HTTP/1.1 200
  ```